### PR TITLE
Added ability to change chime ringtones for motion and dings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ Showing door bell events
         events = doorbell.history(kind='motion')
 
 
-Downloading the last video triggerd by ding
+Downloading the last video triggered by ding
 -------------------------------------------
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -89,9 +89,22 @@ Playing with the attributes
         dev.volume = 5
         print('Volume:     %s' % dev.volume)
 
-        # play dev test shound
-        if dev.family == 'chimes'
+        # play dev test sound
+        if dev.family == 'chimes':
+
+            # play chime
             dev.test_sound
+
+            print("Ringtone ding: %s" % dev.ringtone_ding)
+            print("Ringtone motion: %s" % dev.ringtone_motion)
+
+            # printing available ringtones for motion detection
+            for chime in dev.ringtones_motion_available:
+                print(chime)
+
+            # change ringtone for motion detection
+            dev.ringtone_motion = 'Ding-Dong'
+
 
 
 Showing door bell events

--- a/README.rst
+++ b/README.rst
@@ -89,9 +89,7 @@ Playing with the attributes
         dev.volume = 5
         print('Volume:     %s' % dev.volume)
 
-        # play dev test sound
         if dev.family == 'chimes':
-
             # play chime
             dev.test_sound
 

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -15,19 +15,20 @@ NOT_FOUND = -1
 
 # API endpoints
 API_VERSION = '9'
-API_URI = 'https://api.ring.com'
-CHIMES_ENDPOINT = '/clients_api/chimes/{0}'
-DEVICES_ENDPOINT = '/clients_api/ring_devices'
-DINGS_ENDPOINT = '/clients_api/dings/active'
-DOORBELLS_ENDPOINT = '/clients_api/doorbots/{0}'
-PERSIST_TOKEN_ENDPOINT = '/clients_api/device'
+API_URI = 'https://api.ring.com/clients_api'
+CHIMES_ENDPOINT = '/chimes/{0}'
+DEVICES_ENDPOINT = '/ring_devices'
+DINGS_ENDPOINT = '/dings/active'
+DOORBELLS_ENDPOINT = '/doorbots/{0}'
+NEW_SESSION_ENDPOINT = '/session'
+PERSIST_TOKEN_ENDPOINT = '/device'
+RINGTONES_ENDPOINT = '/ringtones'
+URL_RECORDING = '/dings/{0}/recording'
 
 LINKED_CHIMES_ENDPOINT = CHIMES_ENDPOINT + '/linked_doorbots'
 LIVE_STREAMING_ENDPOINT = DOORBELLS_ENDPOINT + '/vod'
-NEW_SESSION_ENDPOINT = '/clients_api/session'
 TESTSOUND_CHIME_ENDPOINT = CHIMES_ENDPOINT + '/play_sound'
 URL_DOORBELL_HISTORY = DOORBELLS_ENDPOINT + '/history'
-URL_RECORDING = '/clients_api/dings/{0}/recording'
 
 # default values
 CHIME_VOL_MIN = 0
@@ -42,9 +43,10 @@ DOORBELL_EXISTING_TYPE = {
     2: 'Not Present'}
 
 # error strings
-MSG_BOOLEAN_REQUIRED = "Boolean value is required."
-MSG_EXISTING_TYPE = "Integer value where {0}.".format(DOORBELL_EXISTING_TYPE)
+MSG_BOOLEAN_REQUIRED = 'Boolean value is required.'
+MSG_EXISTING_TYPE = 'Integer value where {0}.'.format(DOORBELL_EXISTING_TYPE)
 MSG_GENERIC_FAIL = 'Sorry.. Something went wrong...'
+MSG_NOT_FOUND = 'Not found.'
 FILE_EXISTS = 'The file {0} already exists.'
 MSG_VOL_OUTBOUND = 'Must be within the {0}-{1}.'
 

--- a/ring_doorbell/utils.py
+++ b/ring_doorbell/utils.py
@@ -10,6 +10,16 @@ except ImportError:
     import pickle
 
 
+def _create_list_by_key(lst, key, sort=True):
+    """Return a filtered list by parsing a dictionary by key."""
+    aux = []
+    for member in lst:
+        aux.append(member.get(key))
+    if sort:
+        aux.sort()
+    return aux
+
+
 def _locator(lst, key, value):
     """Return the position of a match item in list."""
     try:


### PR DESCRIPTION
**Description**:

This PR allows the user to modify the chime wave sound for motion and ding for an external Ring chime. 
For example:

```python
from ring_doorbell import Ring
myring = Ring('foo@bar', 'secret')

chime = myring.chimes[0]
chime.name
'Downstairs'

chime.ringtone_ding
'Ding-Dong'

chime.ringtone_motion
'Upbeat'

# changing ringtone
chime.ringtones_ding_available
['Charge!',
 'Ding-Dong',
 'Dogs Barking',
 'Doorbot',
 'Flashback',
 'Harp',
 'Navi',
 'Ring Alert 2',
 'Ring Alert 3',
 'Ring Default',
 'Train Whistle',
 'Triangle',
 'Upbeat',
 'Xylophone']

# this operation takes about 10 seconds to get your chime updated
chime.ringtone_ding = 'Train Whistle'

# wait about 10 seconds and then refresh it
chime.update()

chime.ringtone_ding
'Train Whistle'
```


**Fixes issue**: https://github.com/tchellomello/python-ring-doorbell/issues/19