### PR TITLE
Added the ability to load devices shared to the Ring account. Fixes issue #31

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -179,9 +179,8 @@ class Ring(object):
 
                 # get shared doorbells, however device is read-only
                 req = self.query(url).get('authorized_doorbots')
-                if req:
-                    for member in list((obj['description'] for obj in req)):
-                        lst.append(RingDoorBell(self, member, shared=True))
+                for member in list((obj['description'] for obj in req)):
+                    lst.append(RingDoorBell(self, member, shared=True))
 
         except AttributeError:
             pass

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -245,13 +245,13 @@ class TestRing(unittest.TestCase):
         """Test the Ring class and methods."""
         from ring_doorbell import Ring
 
-        myring = Ring(USERNAME, PASSWORD, persist_token=True)
+        myring = Ring(USERNAME, PASSWORD)
         self.assertTrue(myring.is_connected)
         self.assertIsInstance(myring.features, dict)
         self.assertFalse(myring.debug)
         self.assertEqual(1, len(myring.chimes))
         self.assertEqual(2, len(myring.doorbells))
-        self.assertTrue(myring._persist_token)
+        self.assertFalse(myring._persist_token)
         self.assertEquals('http://localhost/', myring._push_token_notify_url)
 
 
@@ -264,7 +264,7 @@ class TestRingChime(unittest.TestCase):
         """Test the Ring Chime class and methods."""
         from ring_doorbell import Ring
 
-        myring = Ring(USERNAME, PASSWORD, persist_token=True)
+        myring = Ring(USERNAME, PASSWORD)
         dev = myring.chimes[0]
 
         self.assertEqual('123 Main St', dev.address)
@@ -301,6 +301,7 @@ class TestRingDoorBell(unittest.TestCase):
                 self.assertEqual(0, len(dev.history(limit=1, kind='ding')))
 
                 self.assertEqual('Mechanical', dev.existing_doorbell_type)
+                self.assertTrue(myring._persist_token)
 
     @mock.patch('requests.Session.get', side_effect=mocked_requests_get)
     @mock.patch('requests.Session.post', side_effect=mocked_requests_get)


### PR DESCRIPTION
Note that the device will be read-only, however operation such as history
will work as expected. Operation like changing the chime and volume
are not allowed.

```python
from ring_doorbell import Ring

shared_ring = Ring('foor@bar', 'secret')
print(shared_ring.devices)
{'chimes': [], 'doorbells': [<RingDoorBell: Front Door>]}

shared_doorbell = shared_ring.doorbells[0]
shared_doorbell.id = 12345
```

**Fixes issue**: https://github.com/tchellomello/python-ring-doorbell/issues/31