### PR TITLE
Fixes traceback when response is not a list.

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -375,7 +375,7 @@ class RingDoorBell(RingGeneric):
 
         try:
             resp = self._ring.query(url)[0]
-        except IndexError:
+        except (IndexError, TypeError):
             return None
 
         if resp:
@@ -519,7 +519,10 @@ class RingDoorBell(RingGeneric):
     @property
     def last_recording_id(self):
         """Return the last recording ID."""
-        return self.history(limit=1)[0]['id']
+        try:
+            return self.history(limit=1)[0]['id']
+        except (IndexError, TypeError):
+            return None
 
     @property
     def live_streaming_json(self):
@@ -528,7 +531,10 @@ class RingDoorBell(RingGeneric):
         req = self._ring.query((url), method='POST', raw=True)
         if req.status_code == 204:
             url = API_URI + DINGS_ENDPOINT
-            return self._ring.query(url)[0]
+            try:
+                return self._ring.query(url)[0]
+            except (IndexError, TypeError):
+                pass
         return None
 
     def recording_download(self, recording_id, filename=None, override=False):


### PR DESCRIPTION
```python
  File "/home/hass/.homeassistant/custom_components/binary_sensor/ring.py", line 129, in update
    self._data.check_alerts(cache=self._cache)
  File "/home/hass/.homeassistant/deps/ring_doorbell/__init__.py", line 375, in check_alerts
    resp = self._ring.query(url)[0]
TypeError: 'NoneType' object is not subscriptable
```