### PR TITLE
Make session token reusable

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -14,9 +14,10 @@ import requests
 import pytz
 
 from ring_doorbell.utils import (
-    _locator, _clean_cache, _save_cache, _read_cache)
+    _locator, _exists_cache, _save_cache, _read_cache)
 from ring_doorbell.const import (
-    API_VERSION, API_URI, CHIMES_ENDPOINT, CHIME_VOL_MIN, CHIME_VOL_MAX,
+    API_VERSION, API_URI, CACHE_ATTRS, CACHE_FILE, CHIMES_ENDPOINT,
+    CHIME_VOL_MIN, CHIME_VOL_MAX,
     DEVICES_ENDPOINT, DOORBELLS_ENDPOINT, DOORBELL_VOL_MIN, DOORBELL_VOL_MAX,
     DOORBELL_EXISTING_TYPE, DINGS_ENDPOINT, FILE_EXISTS,
     HEADERS, LINKED_CHIMES_ENDPOINT, LIVE_STREAMING_ENDPOINT,
@@ -33,11 +34,10 @@ class Ring(object):
     """A Python Abstraction object to Ring Door Bell."""
 
     def __init__(self, username, password, debug=False, persist_token=False,
-                 push_token_notify_url="http://localhost/"):
+                 push_token_notify_url="http://localhost/", reuse_session=True,
+                 cache_file=CACHE_FILE):
         """Initialize the Ring object."""
-        self.features = None
         self.is_connected = None
-        self._id = None
         self.token = None
         self.params = None
         self._persist_token = persist_token
@@ -49,9 +49,46 @@ class Ring(object):
         self.session = requests.Session()
         self.session.auth = (self.username, self.password)
 
-        self._authenticate()
+        self.cache = CACHE_ATTRS
+        self.cache_file = cache_file
+        self._reuse_session = reuse_session
 
-    def _authenticate(self, attempts=RETRY_TOKEN):
+        # tries to re-use old session
+        if self._reuse_session:
+            self.cache['token'] = self.token
+            self._process_cached_session()
+        else:
+            self._authenticate()
+
+    def _process_cached_session(self):
+        """Process cache_file to reuse token instead."""
+        if _exists_cache(self.cache_file):
+            self.cache = _read_cache(self.cache_file)
+
+            # if self.cache['token'] is None, the cache file was corrupted.
+            # In this case, a new auth token is required.
+            if self.cache['token'] is None:
+                self._authenticate()
+            else:
+                # we need to set the self.token and self.params
+                # to make use of the self.query() method
+                self.token = self.cache['token']
+                self.params = {'api_version': API_VERSION,
+                               'auth_token': self.token}
+
+                # test if token from cache_file is still valid and functional
+                # if not, it should continue to get a new auth token
+                url = API_URI + DEVICES_ENDPOINT
+                req = self.query(url, raw=True)
+                if req.status_code == 200:
+                    self._authenticate(session=req)
+                else:
+                    self._authenticate()
+        else:
+            # first time executing, so we have to create a cache file
+            self._authenticate()
+
+    def _authenticate(self, attempts=RETRY_TOKEN, session=None):
         """Authenticate user against Ring API."""
         url = API_URI + NEW_SESSION_ENDPOINT
 
@@ -59,17 +96,25 @@ class Ring(object):
         while loop <= attempts:
             loop += 1
             try:
-                req = self.session.post((url), data=POST_DATA, headers=HEADERS)
+                if session is None:
+                    req = self.session.post((url),
+                                            data=POST_DATA,
+                                            headers=HEADERS)
+                else:
+                    req = session
             except:
                 raise
 
             # if token is expired, refresh credentials and try again
-            if req.status_code == 201:
-                data = req.json().get('profile')
-                self.features = data.get('features')
-                self._id = data.get('id')
+            if req.status_code == 200 or req.status_code == 201:
+
+                # the only way to get a JSON with token is via POST,
+                # so we need a special conditional for 201 code
+                if req.status_code == 201:
+                    data = req.json().get('profile')
+                    self.token = data.get('authentication_token')
+
                 self.is_connected = True
-                self.token = data.get('authentication_token')
                 self.params = {'api_version': API_VERSION,
                                'auth_token': self.token}
 
@@ -80,6 +125,12 @@ class Ring(object):
                         self._push_token_notify_url
                     req = self.session.put((url), headers=HEADERS,
                                            data=PERSIST_TOKEN_DATA)
+
+                # update token if reuse_session is True
+                if self._reuse_session:
+                    self.cache['token'] = self.token
+
+                _save_cache(self.cache, self.cache_file)
                 return True
 
         self.is_connected = False
@@ -147,14 +198,6 @@ class Ring(object):
         return response
 
     @property
-    def has_subscription(self):
-        """Return if account has subscription."""
-        try:
-            return self.features.get('subscriptions_enabled')
-        except AttributeError:
-            return NOT_FOUND
-
-    @property
     def devices(self):
         """Return all devices."""
         devs = {}
@@ -203,13 +246,12 @@ class RingGeneric(object):
     def __init__(self):
         """Initialize Ring Generic."""
         self._attrs = None
+        self._ring = None
         self.debug = None
         self.family = None
         self.name = None
 
         # alerts notifications
-        self._alert_cache = None
-        self.alert = None
         self.alert_expires_at = None
 
     def __repr__(self):
@@ -221,26 +263,26 @@ class RingGeneric(object):
         self._get_attrs()
         self._update_alert()
 
+    @property
+    def alert(self):
+        """Return alert attribute."""
+        return self._ring.cache['alerts']
+
+    @alert.setter
+    def alert(self, value):
+        """Set attribute to alert."""
+        self._ring.cache['alerts'] = value
+        _save_cache(self._ring.cache, self._ring.cache_file)
+        return True
+
     def _update_alert(self):
         """Verify if alert received is still valid."""
+        # alert is no longer valid
         if self.alert and self.alert_expires_at:
             if datetime.now() >= self.alert_expires_at:
                 self.alert = None
                 self.alert_expires_at = None
-        elif self._alert_cache:
-            aux = _read_cache(self._alert_cache)
-            if ((isinstance(aux, dict)) and
-                    ('now' in aux) and
-                    ('expires_in' in aux)):
-                aux_expires_at = datetime.fromtimestamp(
-                    aux.get('now') + aux.get('expires_in'))
-
-                # verify if pickle object is still valid
-                if datetime.now() <= aux_expires_at:
-                    self.alert = aux
-                    self.alert_expires_at = aux_expires_at
-                else:
-                    _save_cache(None, self._alert_cache)
+                _save_cache(self._ring.cache, self._ring.cache_file)
 
     def _get_attrs(self):
         """Return attributes."""
@@ -371,14 +413,8 @@ class RingDoorBell(RingGeneric):
             value = 100
         return value
 
-    def check_alerts(self, cache=None):
+    def check_alerts(self):
         """Return JSON when motion or ring is detected."""
-        # save alerts attributes to an external pickle file
-        # when multiple resources are checking for alerts
-        if cache:
-            _clean_cache(cache)
-            self._alert_cache = cache
-
         url = API_URI + DINGS_ENDPOINT
         self.update()
 
@@ -393,8 +429,8 @@ class RingDoorBell(RingGeneric):
             self.alert_expires_at = datetime.fromtimestamp(timestamp)
 
             # save to a pickle data
-            if self._alert_cache:
-                _save_cache(self.alert, self._alert_cache)
+            if self.alert:
+                _save_cache(self._ring.cache, self._ring.cache_file)
             return True
         return None
 

--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -50,6 +50,7 @@ class Ring(object):
         self.session.auth = (self.username, self.password)
 
         self.cache = CACHE_ATTRS
+        self.cache['account'] = self.username
         self.cache_file = cache_file
         self._reuse_session = reuse_session
 
@@ -66,8 +67,11 @@ class Ring(object):
             self.cache = _read_cache(self.cache_file)
 
             # if self.cache['token'] is None, the cache file was corrupted.
-            # In this case, a new auth token is required.
-            if self.cache['token'] is None:
+            # of if self.cache['account'] does not match with self.username
+            # In both cases, a new auth token is required.
+            if (self.cache['token'] is None) or \
+               (self.cache['account'] is None) or \
+               (self.cache['account'] != self.username):
                 self._authenticate()
             else:
                 # we need to set the self.token and self.params
@@ -128,6 +132,7 @@ class Ring(object):
 
                 # update token if reuse_session is True
                 if self._reuse_session:
+                    self.cache['account'] = self.username
                     self.cache['token'] = self.token
 
                 _save_cache(self.cache, self.cache_file)

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -14,10 +14,12 @@ RETRY_TOKEN = 3
 # default suffix for session cache file
 CACHE_ATTRS = {'token': None, 'alerts': None}
 
-HOMEDIR = os.getenv("HOME")
-if not HOMEDIR:
-    HOMEDIR = ''
-CACHE_FILE = os.path.join(HOMEDIR, '.ring_doorbell-session.cache')
+try:
+    CACHE_FILE = os.path.join(os.getenv("HOME"),
+                              '.ring_doorbell-session.cache')
+except (AttributeError, TypeError):
+    CACHE_FILE = os.path.join('.', '.ring_doorbell-session.cache')
+
 
 # code when item was not found
 NOT_FOUND = -1

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 # vim:sw=4:ts=4:et:
 """Constants."""
+import os
 from uuid import uuid4 as uuid
 
 HEADERS = {'Content-Type': 'application/x-www-form-urlencoded; charset: UTF-8',
@@ -9,6 +10,14 @@ HEADERS = {'Content-Type': 'application/x-www-form-urlencoded; charset: UTF-8',
 
 # number of attempts to refresh token
 RETRY_TOKEN = 3
+
+# default suffix for session cache file
+CACHE_ATTRS = {'token': None, 'alerts': None}
+
+HOMEDIR = os.getenv("HOME")
+if not HOMEDIR:
+    HOMEDIR = ''
+CACHE_FILE = os.path.join(HOMEDIR, '.ring_doorbell-session.cache')
 
 # code when item was not found
 NOT_FOUND = -1

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -12,7 +12,7 @@ HEADERS = {'Content-Type': 'application/x-www-form-urlencoded; charset: UTF-8',
 RETRY_TOKEN = 3
 
 # default suffix for session cache file
-CACHE_ATTRS = {'token': None, 'alerts': None}
+CACHE_ATTRS = {'account': None, 'alerts': None, 'token': None}
 
 try:
     CACHE_FILE = os.path.join(os.getenv("HOME"),

--- a/ring_doorbell/utils.py
+++ b/ring_doorbell/utils.py
@@ -52,7 +52,13 @@ def _read_cache(filename):
     """Read data from a pickle file."""
     try:
         if os.path.isfile(filename):
-            return pickle.load(open(filename, 'rb'))
+            data = pickle.load(open(filename, 'rb'))
+
+            # make sure pickle obj has the expected defined keys
+            # if not reinitialize cache
+            if data.keys() != CACHE_ATTRS.keys():
+                raise EOFError
+            return data
     except EOFError:
         return _clean_cache(filename)
     except:

--- a/ring_doorbell/utils.py
+++ b/ring_doorbell/utils.py
@@ -2,7 +2,7 @@
 # vim:sw=4:ts=4:et:
 """Python Ring Doorbell utils."""
 import os
-from ring_doorbell.const import NOT_FOUND
+from ring_doorbell.const import CACHE_ATTRS, NOT_FOUND
 
 try:
     import cPickle as pickle
@@ -23,10 +23,19 @@ def _clean_cache(filename):
     """Remove filename if pickle version mismatch."""
     try:
         if os.path.isfile(filename):
-            _read_cache(filename)
-    except ValueError:
-        os.remove(filename)
-    return True
+            os.remove(filename)
+    except:
+        raise
+
+    # initialize cache since file was removed
+    initial_cache_data = CACHE_ATTRS
+    _save_cache(initial_cache_data, filename)
+    return initial_cache_data
+
+
+def _exists_cache(filename):
+    """Check if filename exists and if is pickle object."""
+    return bool(os.path.isfile(filename))
 
 
 def _save_cache(data, filename):
@@ -44,5 +53,7 @@ def _read_cache(filename):
     try:
         if os.path.isfile(filename):
             return pickle.load(open(filename, 'rb'))
+    except EOFError:
+        return _clean_cache(filename)
     except:
         raise

--- a/tests/test_ring_utils.py
+++ b/tests/test_ring_utils.py
@@ -3,6 +3,7 @@ import os
 import unittest
 from ring_doorbell.utils import (
     _locator, _clean_cache, _exists_cache, _save_cache, _read_cache)
+from ring_doorbell.const import CACHE_ATTRS
 
 CACHE = 'tests/cache.db'
 FAKE = 'tests/fake.db'
@@ -38,5 +39,11 @@ class TestUtils(unittest.TestCase):
     def test_read_cache_eoferror(self):
         """Test _read_cache method."""
         open(CACHE, 'a').close()
+        self.assertIsInstance(_read_cache(CACHE), dict)
+        os.remove(CACHE)
+
+    def test_read_cache_dict(self):
+        """Test _read_cache with expected dict."""
+        self.assertTrue(_save_cache(CACHE_ATTRS, CACHE))
         self.assertIsInstance(_read_cache(CACHE), dict)
         os.remove(CACHE)

--- a/tests/test_ring_utils.py
+++ b/tests/test_ring_utils.py
@@ -1,0 +1,42 @@
+"""The tests utils.py for the Ring platform."""
+import os
+import unittest
+from ring_doorbell.utils import (
+    _locator, _clean_cache, _exists_cache, _save_cache, _read_cache)
+
+CACHE = 'tests/cache.db'
+FAKE = 'tests/fake.db'
+DATA = {'key': 'value'}
+
+
+class TestUtils(unittest.TestCase):
+    """Test utils.py."""
+
+    def test_locator(self):
+        """Test _locator method."""
+        self.assertEquals(-1, _locator([DATA], 'key', 'bar'))
+        self.assertEquals(0, _locator([DATA], 'key', 'value'))
+
+    def test_initiliaze_clean_cache(self):
+        """Test _clean_cache method."""
+        self.assertTrue(_save_cache(DATA, CACHE))
+        self.assertIsInstance(_clean_cache(CACHE), dict)
+        os.remove(CACHE)
+
+    def test_exists_cache(self):
+        """Test _exists_cache method."""
+        self.assertTrue(_save_cache(DATA, CACHE))
+        self.assertTrue(_exists_cache(CACHE))
+        os.remove(CACHE)
+
+    def test_read_cache(self):
+        """Test _read_cache method."""
+        self.assertTrue(_save_cache(DATA, CACHE))
+        self.assertIsInstance(_read_cache(CACHE), dict)
+        os.remove(CACHE)
+
+    def test_read_cache_eoferror(self):
+        """Test _read_cache method."""
+        open(CACHE, 'a').close()
+        self.assertIsInstance(_read_cache(CACHE), dict)
+        os.remove(CACHE)


### PR DESCRIPTION
Make session token reusable across multiple object instances via cache file.

With this patch, we can have more than one Ring object pointing to the same cache file
to share credentials to avoid multiple authentications.

If a different account is being informed, the cache file is regenerated.

This fix some issues of Ring accounts being disabled due to multiple auths.