### PR TITLE
chime: Support playing motion test sound

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,8 @@ Listing devices linked to your account
     myring.doorbells
     [<RingDoorBell: Front Door>]
 
-Playing with the attributes
----------------------------
+Playing with the attributes and functions
+-----------------------------------------
 .. code-block:: python
 
     for dev in list(myring.chimes + myring.doorbells):
@@ -88,7 +88,8 @@ Playing with the attributes
 
         # play dev test shound
         if dev.family == 'chimes'
-            dev.test_sound
+            dev.test_sound(kind = 'ding')
+            dev.test_sound(kind = 'motion')
 
 
 Showing door bell events

--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -25,7 +25,7 @@ from ring_doorbell.const import (
     MSG_GENERIC_FAIL, MSG_VOL_OUTBOUND,
     NOT_FOUND, URL_DOORBELL_HISTORY, URL_RECORDING,
     POST_DATA, PERSIST_TOKEN_ENDPOINT, PERSIST_TOKEN_DATA,
-    RETRY_TOKEN, TESTSOUND_CHIME_ENDPOINT)
+    RETRY_TOKEN, TESTSOUND_CHIME_ENDPOINT, CHIME_TEST_SOUND_KINDS, KIND_DING)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -388,11 +388,12 @@ class RingChime(RingGeneric):
         url = API_URI + LINKED_CHIMES_ENDPOINT.format(self.account_id)
         return self._ring.query(url)
 
-    @property
-    def test_sound(self):
+    def test_sound(self, kind=KIND_DING):
         """Play chime to test sound."""
+        if kind not in CHIME_TEST_SOUND_KINDS:
+            return False
         url = API_URI + TESTSOUND_CHIME_ENDPOINT.format(self.account_id)
-        self._ring.query(url, method='POST')
+        self._ring.query(url, method='POST', extra_params={"kind": kind})
         return True
 
 

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -40,6 +40,11 @@ TESTSOUND_CHIME_ENDPOINT = CHIMES_ENDPOINT + '/play_sound'
 URL_DOORBELL_HISTORY = DOORBELLS_ENDPOINT + '/history'
 URL_RECORDING = '/clients_api/dings/{0}/recording'
 
+# chime test sound kinds
+KIND_DING = 'ding'
+KIND_MOTION = 'motion'
+CHIME_TEST_SOUND_KINDS = (KIND_DING, KIND_MOTION)
+
 # default values
 CHIME_VOL_MIN = 0
 CHIME_VOL_MAX = 10


### PR DESCRIPTION
Changes the test_sound property to be a function.

Fixes Issue #28.

Please let me know if this change needs to be backward compatible. I can make it another property in that case. (Also thanks for the pointer on mitmproxy, worked like a charm!)