### PR TITLE
Allows history to enforce to return minimum number of events for a given type

### DIFF
--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -78,6 +78,10 @@ class TestRing(RingUnitTestBase):
                 self.assertIsInstance(dev.history(limit=1, kind='motion'),
                                       list)
                 self.assertEqual(0, len(dev.history(limit=1, kind='ding')))
+                self.assertEqual(0, len(dev.history(limit=1,
+                                                    kind='ding',
+                                                    enforce_limit=True,
+                                                    retry=50)))
 
                 self.assertEqual('Mechanical', dev.existing_doorbell_type)
                 self.assertTrue(data._persist_token)


### PR DESCRIPTION
Allow the user to call `history()` to select a specific number of events of a given kind. 

**Fixes**: #45 

```python
from ring_doorbell import Ring
myring = Ring('user', 'password')
doorbell = myring.doorbells[0]


# showing all my last 3 events captured by the camera
[z.get('kind') for z in doorbell.history(limit=3)]
['motion', 'motion', 'motion']

# no events were listed because it looked up the last 3 events which are motion not kind
[z.get('kind') for z in doorbell.history(limit=3, kind='ding')]
[] 

# however it can be enforced now with this PR
[z.get('kind') for z in doorbell.history(limit=3, kind='ding', enforce_limit=True)]
['ding', 'ding', 'ding']

# it is also possible to determine how many times the query will be executed until the limit is reached
[z.get('kind') for z in doorbell.history(limit=3, kind='ding', enforce_limit=True, retry=1)]
WARNING:ring_doorbell.doorbot:Could not find total of 3 of kind ding
[]

[z.get('kind') for z in doorbell.history(limit=3, kind='ding', enforce_limit=True, retry=4)]
WARNING:ring_doorbell.doorbot:Could not find total of 3 of kind ding
['ding', 'ding']

[z.get('kind') for z in doorbell.history(limit=3, kind='ding', enforce_limit=True, retry=8)]
['ding', 'ding', 'ding']
```

@asantaga  I had to add the new parameter `enforce_limit` to don't the current API. So this way, the old behavior continues the same, however it can be enforced now with the new parameters. 

 Please give a try or let me know if that looks for your so then we can commit and publish the newer version since this is the last issue for the `0.1.5` milestone. 

Thank you!