### PR TITLE
Allows `older_than` parameter to history() method

### DIFF
--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -155,7 +155,7 @@ class RingDoorBell(RingGeneric):
         return None
 
     def history(self, limit=30, timezone=None, kind=None,
-                enforce_limit=False, retry=8):
+                enforce_limit=False, older_than=None, retry=8):
         """
         Return history with datetime objects.
 
@@ -163,6 +163,7 @@ class RingDoorBell(RingGeneric):
         :param timezone: determine which timezone to convert data objects
         :param kind: filter by kind (ding, motion, on_demand)
         :param enforce_limit: when True, this will enforce the limit and kind
+        :param older_than: return older objects than the passed event_id
         :param retry: determine the max number of attempts to archive the limit
         """
         queries = 0
@@ -174,6 +175,8 @@ class RingDoorBell(RingGeneric):
 
         while True:
             params = {'limit': str(limit)}
+            if older_than:
+                params['older_than'] = older_than
 
             url = API_URI + URL_DOORBELL_HISTORY.format(self.account_id)
             response = self._ring.query(url, extra_params=params)

--- a/scripts/ringcli.py
+++ b/scripts/ringcli.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# vim:sw=4:ts=4:et
+# Many thanks to @troopermax <https://github.com/troopermax>
+
+import getpass
+import argparse
+from ring_doorbell import Ring
+
+
+def _header():
+    _bar()
+    print("Ring CLI")
+
+
+def _bar():
+    print('---------------------------------')
+
+
+def get_username():
+    try:
+        username = raw_input("Username: ")
+    except NameError:
+        username = input("Username: ")
+    return username
+
+
+def _format_filename(event):
+    if not isinstance(event, dict):
+        return
+
+    if event['answered']:
+        answered_status = 'answered'
+    else:
+        answered_status = 'not_answered'
+
+    filename = "{}_{}_{}_{}".format(event['created_at'],
+                                    event['kind'],
+                                    answered_status,
+                                    event['id'])
+
+    filename = filename.replace(' ', '_').replace(':', '.')+'.mp4'
+    return filename
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+            description='Ring Doorbell',
+            epilog='https://github.com/tchellomello/python-ring-doorbell',
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument('-u',
+                        '--username',
+                        dest='username',
+                        type=str,
+                        help='username for Ring account')
+
+    parser.add_argument('-p',
+                        '--password',
+                        type=str,
+                        dest='password',
+                        help='username for Ring account')
+
+    parser.add_argument('--count',
+                        action='store_true',
+                        default=False,
+                        help='count the number of videos on your Ring account')
+
+    parser.add_argument('--download-all',
+                        action='store_true',
+                        default=False,
+                        help='download all videos on your Ring account')
+
+    args = parser.parse_args()
+    _header()
+
+    if not args.username:
+        args.username = get_username()
+
+    if not args.password:
+        args.password = getpass.getpass("Password: ")
+
+    # connect to Ring account
+    myring = Ring(args.username, args.password)
+    doorbell = myring.doorbells[0]
+
+    _bar()
+
+    if args.count:
+        print("\tCounting videos linked on your Ring account.\n" +
+              "\tThis may take some time....\n")
+
+        events = []
+        counter = 0
+        history = doorbell.history(limit=100)
+        while (len(history) > 0):
+            events += history
+            counter += len(history)
+            history = doorbell.history(older_than=history[-1]['id'])
+
+        motion = len([m['kind'] for m in events if m['kind'] == 'motion'])
+        ding = len([m['kind'] for m in events if m['kind'] == 'ding'])
+        on_demand = \
+            len([m['kind'] for m in events if m['kind'] == 'on_demand'])
+
+        print("\tTotal videos: {}".format(counter))
+        print("\tDing triggered: {}".format(ding))
+        print("\tMotion triggered: {}".format(motion))
+        print("\tOn-Demand triggered: {}".format(on_demand))
+
+        # already have all events in memory
+        if args.download_all:
+            counter = 0
+            print("\tDownloading all videos linked on your Ring account.\n" +
+                  "\tThis may take some time....\n")
+
+            for event in events:
+                counter += 1
+                filename = _format_filename(event)
+                print("\t{}/{} Downloading {}".format(counter,
+                                                      len(events),
+                                                      filename))
+
+                doorbell.recording_download(event['id'],
+                                            filename=filename,
+                                            override=False)
+
+    if args.download_all and not args.count:
+        print("\tDownloading all videos linked on your Ring account.\n" +
+              "\tThis may take some time....\n")
+        history = doorbell.history(limit=100)
+
+        while (len(history) > 0):
+            print("\tProcessing and downloading the next" +
+                  " videos".format(len(history)))
+
+            counter = 0
+            for event in history:
+                counter += 1
+                filename = _format_filename(event)
+                print("\t{}/{} Downloading {}".format(counter,
+                                                      len(history),
+                                                      filename))
+
+                doorbell.recording_download(event['id'],
+                                            filename=filename,
+                                            override=False)
+
+            history = doorbell.history(limit=100, older_than=history[-1]['id'])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
 - Added ability to pass the parameter 'older_than' to history() method
 - Added script which allows count the number of videos and download them

```bash
scripts/ringcli.py -u foo -p bar --count
---------------------------------
Ring CLI
---------------------------------
	Counting videos linked on your Ring account.
	This may take some time....

	Total videos: 384
	Ding triggered: 32
	Motion triggered: 340
	On-Demand triggered: 12

======================

---------------------------------
Ring CLI
---------------------------------
scripts/ringcli.py -u foo -p bar --count
	1/384 Downloading 2017-11-14_00.57.16+00.00_motion_answered_64880679462719.mp4
	2/384 Downloading 2017-11-13_21.32.23+00.00_motion_not_answered_64880151491.mp4
======================

scripts/ringcli.py --help
usage: ringcli.py [-h] [-u USERNAME] [-p PASSWORD] [--count] [--download-all]

Ring Doorbell

optional arguments:
  -h, --help            show this help message and exit
  -u USERNAME, --username USERNAME
                        username for Ring account
  -p PASSWORD, --password PASSWORD
                        username for Ring account
  --count               count the number of videos on your Ring account
  --download-all        download all videos on your Ring account

https://github.com/tchellomello/python-ring-doorbell
```
Fixes: #63 

Many thanks to @troopermax for reporting the issue and suggesting the addition 