### PR TITLE
Added controllter to verify if account has subscription

### DIFF
--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -247,6 +247,11 @@ class RingDoorBell(RingGeneric):
 
     def recording_download(self, recording_id, filename=None, override=False):
         """Save a recording in MP4 format to a file or return raw."""
+        if not self.has_subscription:
+            _LOGGER.warning("Your Ring account does not have" +
+                            " an active subscription.")
+            return False
+
         url = API_URI + URL_RECORDING.format(recording_id)
         try:
             req = self._ring.query(url, raw=True)
@@ -268,6 +273,11 @@ class RingDoorBell(RingGeneric):
 
     def recording_url(self, recording_id):
         """Return HTTPS recording URL."""
+        if not self.has_subscription:
+            _LOGGER.warning("Your Ring account does not have" +
+                            " an active subscription.")
+            return False
+
         url = API_URI + URL_RECORDING.format(recording_id)
         req = self._ring.query(url, raw=True)
         if req and req.status_code == 200:
@@ -289,6 +299,11 @@ class RingDoorBell(RingGeneric):
         if result is None:
             return False
         return True
+
+    @property
+    def has_subscription(self):
+        """Return boolean if the account has subscription."""
+        return self._attrs.get('features').get('show_recordings')
 
     @property
     def volume(self):

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -74,6 +74,7 @@ class TestRing(RingUnitTestBase):
                 self.assertEqual(-70.12345, dev.longitude)
                 self.assertEqual('America/New_York', dev.timezone)
                 self.assertEqual(1, dev.volume)
+                self.assertTrue(dev.has_subscription)
                 self.assertEqual('online', dev.connection_status)
 
                 self.assertIsInstance(dev.history(limit=1, kind='motion'),


### PR DESCRIPTION
Added a layer to verify if the account has an active subscription. 

```bash
In [12]: not_subscription.recording_url(not_subscription.last_recording_id)
Out[12]: False

In [13]: has_subscription.recording_url(has_subscription.last_recording_id)
Out[13]: 'https://ring-transcoded-videos.s3.amazonaws.com/6490927797489893075.mp4?X-Amz-Expires=3600&X-Amz-Date=20171121T230526Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJU3<REDACTED>.....'

In [14]: has_subscription.has_subscription
Out[14]: True

In [15]: not_subscription.has_subscription
Out[15]: False
```


Fixes: #71 
Mentioned by: https://github.com/home-assistant/home-assistant/issues/10736