### PR TITLE
Created generic update method for all devices on Ring top-parent object

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -253,3 +253,12 @@ class Ring(object):
     def doorbells(self):
         """Return a list of RingDoorBell objects."""
         return self.__devices('doorbells')
+
+    def update(self):
+        """Refreshes attributes for all linked devices."""
+        for device_lst in self.devices.values():
+            for device in device_lst:
+                if hasattr(device, "update"):
+                    _LOGGER.debug("Updating attributes from %s", device.name)
+                    getattr(device, "update")
+        return True

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -28,6 +28,8 @@ class RingUnitTestBase(unittest.TestCase):
         self.ring_persistent = \
             Ring(USERNAME, PASSWORD, cache_file=CACHE, persist_token=True)
 
+        self.assertTrue(hasattr(self.ring, "update"))
+
     def cleanup(self):
         """Cleanup any data created from the tests."""
         self.ring = None


### PR DESCRIPTION
This method will call recursively all devices linked to the Ring account and update its attributes. 


Fixes: #74 

```python
from ring_doorbell import Ring

myring = Ring('foo', 'bar')
myring.update()
```