### PR TITLE
Make sure battery_life argument exists before comparison

### DIFF
--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -30,8 +30,8 @@ class RingDoorBell(RingGeneric):
     @property
     def battery_life(self):
         """Return battery life."""
-        value = int(self._attrs.get('battery_life'))
-        if value > 100:
+        value = self._attrs.get('battery_life')
+        if value and value > 100:
             value = 100
         return value
 


### PR DESCRIPTION
 Fixes #86 

 Make sure battery_life argument exists before comparison

```
 value = int(self._attrs.get('battery_life'))
 TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```