### PR TITLE
Fixes battery_life attribute because sometimes the JSON return a str instead of an int

### DIFF
--- a/ring_doorbell/chime.py
+++ b/ring_doorbell/chime.py
@@ -23,7 +23,7 @@ class RingChime(RingGeneric):
     @property
     def battery_life(self):
         """Return battery life."""
-        return self._health_attrs.get('battery_percentage')
+        return int(self._health_attrs.get('battery_percentage'))
 
     @property
     def volume(self):

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -30,7 +30,7 @@ class RingDoorBell(RingGeneric):
     @property
     def battery_life(self):
         """Return battery life."""
-        value = self._attrs.get('battery_life')
+        value = int(self._attrs.get('battery_life'))
         if value and value > 100:
             value = 100
         return value


### PR DESCRIPTION
Fixes battery_life attribute because sometimes the JSON return a str instead of an int

Fixes: #91 

```python
>>>from ring_doorbell import Ring
>>>from pprint import pprint
>>>myring = Ring('user', 'pass', 'true')
>>>obj = myring.doorbells[0] #Front Door door bell
>>>pprint(vars(obj))
{'_attrs': {u'address': u'address',
            u'alerts': {u'connection': u'online'},
            u'battery_life': u'58',
            u'description': u'Front Door',
....
'_health_attrs': {u'average_signal_category': u'good',
                   u'average_signal_strength': -49,
                   u'battery_percentage': u'58',
                   u'battery_percentage_category': u'good',
                   u'battery_voltage': None,
                   u'battery_voltage_category': None,
                   u'firmware': u'Up to Date',

>>>print(obj.battery_life)
100
>>>print (obj._attrs["battery_life"])
58
>>>print(obj._health_attrs.get('battery_percentage'))
58
```

The issue happens when the attribute is a string

```python
In [1]: a = u'58'

In [2]: a > 100
Out[2]: True
```

To fix, basically let's cast that value: 

```python
In [1]: a = u'58'

In [2]: a > 100
Out[2]: True

In [3]: int(a) > 100
Out[3]: False
```