### PR TITLE
Support for Spotlight Battery cameras with multiple battery bays

### DIFF
--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -30,6 +30,17 @@ class RingDoorBell(RingGeneric):
     @property
     def battery_life(self):
         """Return battery life."""
+        if 'battery_life_2' in self._attrs:
+            # Camera has two battery bays
+            value = 0
+            if self._attrs.get('battery_life') is not None:
+                # Bay 1
+                value += int(self._attrs.get('battery_life'))
+            if self._attrs.get('battery_life_2') is not None:
+                # Bay 2
+                value += int(self._attrs.get('battery_life_2'))
+            return value
+        # Camera has a single battery bay
         value = int(self._attrs.get('battery_life'))
         if value and value > 100:
             value = 100


### PR DESCRIPTION
Intended to help resolve https://github.com/home-assistant/home-assistant/issues/17932.

The Spotlight Cam Battery has two battery bays. When the 1st bay is empty, the ring API returns null for the `battery_life` key. This causes the `battery_life` getter to fall over as it attempts to cast `None` to `int`.

I've changed the behaviour to return the sum of the two battery values, ignoring None values.

Thanks for developing this library + the home assistant component! 