### PR TITLE
Add a couple of device kinds

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -78,11 +78,11 @@ DOORBELL_2_KINDS = ['doorbell_v4', 'doorbell_v5']
 DOORBELL_PRO_KINDS = ['lpd_v1', 'lpd_v2']
 DOORBELL_ELITE_KINDS = ['jbox_v1']
 
-FLOODLIGHT_CAM_KINDS = ['hp_cam_v1']
+FLOODLIGHT_CAM_KINDS = ['hp_cam_v1', 'floodlight_v2']
 SPOTLIGHT_CAM_BATTERY_KINDS = ['stickup_cam_v4']
 SPOTLIGHT_CAM_WIRED_KINDS = ['hp_cam_v2']
 STICKUP_CAM_KINDS = ['stickup_cam', 'stickup_cam_v3']
-STICKUP_CAM_BATTERY_KINDS = ['stickup_cam_lunar']
+STICKUP_CAM_BATTERY_KINDS = ['cocoa_camera', 'stickup_cam_lunar']
 STICKUP_CAM_WIRED_KINDS = ['stickup_cam_elite']
 
 # error strings


### PR DESCRIPTION
I am not sure if anything else is needed but I found that adding these values allowed for certain capabilities to register properly.

There is also a Door View device which registers as `doorbell_portal` and allows the user to detect door knocks under the `Kind` `door_activity` but it seems all doorbells show this attribute so I am not sure how to distinguish it properly.  If anyone has any suggestions on how to add this properly that would be best.  Until then there is a small modification to add to Home Assistant that shows the knock sensor but it shows up for all doorbells which is not desirable.