### PR TITLE
Add additional device kinds for new products

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -70,17 +70,19 @@ SIREN_DURATION_MIN = 0
 SIREN_DURATION_MAX = 120
 
 # device model kinds
-CHIME_KINDS = ['chime']
-CHIME_PRO_KINDS = ['chime_pro']
+CHIME_KINDS = ['chime', 'chime_v2']
+CHIME_PRO_KINDS = ['chime_pro', 'chime_pro_v2']
 
 DOORBELL_KINDS = ['doorbot', 'doorbell', 'doorbell_v3']
 DOORBELL_2_KINDS = ['doorbell_v4', 'doorbell_v5']
 DOORBELL_PRO_KINDS = ['lpd_v1', 'lpd_v2']
 DOORBELL_ELITE_KINDS = ['jbox_v1']
+PEEPHOLE_CAM_KINDS = ['doorbell_portal']
 
 FLOODLIGHT_CAM_KINDS = ['hp_cam_v1', 'floodlight_v2']
+INDOOR_CAM_KINDS = ['stickup_cam_mini']
 SPOTLIGHT_CAM_BATTERY_KINDS = ['stickup_cam_v4']
-SPOTLIGHT_CAM_WIRED_KINDS = ['hp_cam_v2']
+SPOTLIGHT_CAM_WIRED_KINDS = ['hp_cam_v2', 'spotlightw_v2']
 STICKUP_CAM_KINDS = ['stickup_cam', 'stickup_cam_v3']
 STICKUP_CAM_BATTERY_KINDS = ['cocoa_camera', 'stickup_cam_lunar']
 STICKUP_CAM_WIRED_KINDS = ['stickup_cam_elite']

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -16,9 +16,9 @@ from ring_doorbell.const import (
     DOORBELL_EXISTING_TYPE, DINGS_ENDPOINT, DOORBELL_KINDS,
     DOORBELL_2_KINDS, DOORBELL_PRO_KINDS, DOORBELL_ELITE_KINDS,
     FILE_EXISTS, LIVE_STREAMING_ENDPOINT, MSG_BOOLEAN_REQUIRED,
-    MSG_EXISTING_TYPE, MSG_VOL_OUTBOUND, SNAPSHOT_ENDPOINT,
-    SNAPSHOT_TIMESTAMP_ENDPOINT, URL_DOORBELL_HISTORY,
-    URL_RECORDING)
+    MSG_EXISTING_TYPE, MSG_VOL_OUTBOUND, PEEPHOLE_CAM_KINDS,
+    SNAPSHOT_ENDPOINT, SNAPSHOT_TIMESTAMP_ENDPOINT,
+    URL_DOORBELL_HISTORY, URL_RECORDING)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,13 +42,18 @@ class RingDoorBell(RingGeneric):
             return 'Doorbell Pro'
         elif self.kind in DOORBELL_ELITE_KINDS:
             return 'Doorbell Elite'
+        elif self.kind in PEEPHOLE_CAM_KINDS:
+            return 'Peephole Cam'
         return None
 
     def has_capability(self, capability):
         """Return if device has specific capability."""
         if capability == 'battery':
             return self.kind in (DOORBELL_KINDS +
-                                 DOORBELL_2_KINDS)
+                                 DOORBELL_2_KINDS +
+                                 PEEPHOLE_CAM_KINDS)
+        elif capability == 'knock':
+            return self.kind in PEEPHOLE_CAM_KINDS
         elif capability == 'volume':
             return True
         return False

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -6,7 +6,7 @@ import logging
 from ring_doorbell import RingDoorBell
 from ring_doorbell.const import (
     API_URI, LIGHTS_ENDPOINT, MSG_ALLOWED_VALUES, MSG_VOL_OUTBOUND,
-    FLOODLIGHT_CAM_KINDS, SPOTLIGHT_CAM_BATTERY_KINDS,
+    FLOODLIGHT_CAM_KINDS, INDOOR_CAM_KINDS, SPOTLIGHT_CAM_BATTERY_KINDS,
     SPOTLIGHT_CAM_WIRED_KINDS, STICKUP_CAM_KINDS,
     STICKUP_CAM_BATTERY_KINDS, STICKUP_CAM_WIRED_KINDS,
     SIREN_DURATION_MIN, SIREN_DURATION_MAX, SIREN_ENDPOINT)
@@ -27,6 +27,8 @@ class RingStickUpCam(RingDoorBell):
         """Return Ring device model name."""
         if self.kind in FLOODLIGHT_CAM_KINDS:
             return 'Floodlight Cam'
+        elif self.kind in INDOOR_CAM_KINDS:
+            return 'Indoor Cam'
         elif self.kind in SPOTLIGHT_CAM_BATTERY_KINDS:
             return 'Spotlight Cam {}'.format(
                 self._attrs.get('ring_cam_setup_flow', 'battery').title())
@@ -53,6 +55,7 @@ class RingStickUpCam(RingDoorBell):
                                  SPOTLIGHT_CAM_WIRED_KINDS)
         elif capability == 'siren':
             return self.kind in (FLOODLIGHT_CAM_KINDS +
+                                 INDOOR_CAM_KINDS +
                                  SPOTLIGHT_CAM_BATTERY_KINDS +
                                  SPOTLIGHT_CAM_WIRED_KINDS +
                                  STICKUP_CAM_BATTERY_KINDS +


### PR DESCRIPTION
Related to #135, I added additional device kinds for new products based on the latest Ring App APK. This also includes adding the new knock detection capability check for the Peephole Cam.

Although, this should covers all the recent Ring product changes. From parsing the APK, it seems that the new Stick Up Cam is using the same device kind `cocoa_camera` for the battery and wire-in models. At this point, I am not sure how the app is able to differentiate them.

Moreover, there is a device kind called `doorbell_scallop` which could be the latest generation Doorbell 2 product but it's hard to tell. One thing for sure is that it is a battery operated product. Therefore, I omitted this device kind for the time being.

Finally, the 2nd generation of the Stick Up Cam Elite is identified as `stickup_cam_elite_v2` in the app but it is still linked to device kind `stickup_cam_elite`. So another open question on how it can be differentiated from the previous generation (Elite vs Wired) which I believe doesn't have POE built-in.