### PR TITLE
Fix/oauth fail due to blocked user agent

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -101,7 +101,7 @@ class Ring(object):
             oauth_token = response.json().get('access_token')
         return oauth_token
 
-    def _authenticate(self, attempts=RETRY_TOKEN, session=None):
+    def _authenticate(self, attempts=RETRY_TOKEN, session=None, wait=1.0):
         """Authenticate user against Ring API."""
         url = API_URI + NEW_SESSION_ENDPOINT
         loop = 0
@@ -126,7 +126,7 @@ class Ring(object):
                 raise
 
             if not req:
-                time.sleep(5)  # add a pause or you'll get rate limited (429)
+                time.sleep(wait)  # add a pause or you'll get rate limited
                 continue
 
             # if token is expired, refresh credentials and try again
@@ -199,11 +199,13 @@ class Ring(object):
             loop += 1
             try:
                 if method == 'GET':
-                    req = self.session.get((url), params=urlencode(params),
-                              headers=auth_header)
+                    req = self.session.get(
+                        (url), params=urlencode(params),
+                        headers=auth_header)
                 elif method == 'PUT':
-                    req = self.session.put((url), params=urlencode(params),
-                              headers=auth_header)
+                    req = self.session.put(
+                        (url), params=urlencode(params),
+                        headers=auth_header)
                 elif method == 'POST':
                     req = self.session.post(
                         (url), params=urlencode(params), json=json,

--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -180,7 +180,7 @@ class Ring(object):
         # queries now need a bearer token or you'll get 401s
         auth_header = {}
         auth_header['Authorization'] = \
-                'Bearer {}'.format(self._get_oauth_token())
+            'Bearer {}'.format(self._get_oauth_token())
 
         response = None
         loop = 0
@@ -199,12 +199,15 @@ class Ring(object):
             loop += 1
             try:
                 if method == 'GET':
-                    req = self.session.get((url), params=urlencode(params), headers=auth_header)
+                    req = self.session.get((url), params=urlencode(params),
+                        headers=auth_header)
                 elif method == 'PUT':
-                    req = self.session.put((url), params=urlencode(params), headers=auth_header)
+                    req = self.session.put((url), params=urlencode(params),
+                        headers=auth_header)
                 elif method == 'POST':
                     req = self.session.post(
-                        (url), params=urlencode(params), json=json, headers=auth_header)
+                        (url), params=urlencode(params), json=json,
+                        headers=auth_header)
 
                 if self.debug:
                     _LOGGER.debug("_query %s ret %s", loop, req.status_code)

--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -200,10 +200,10 @@ class Ring(object):
             try:
                 if method == 'GET':
                     req = self.session.get((url), params=urlencode(params),
-                        headers=auth_header)
+                              headers=auth_header)
                 elif method == 'PUT':
                     req = self.session.put((url), params=urlencode(params),
-                        headers=auth_header)
+                              headers=auth_header)
                 elif method == 'POST':
                     req = self.session.post(
                         (url), params=urlencode(params), json=json,

--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -7,8 +7,8 @@ except ImportError:
     from urllib import urlencode
 
 import logging
-import requests
 import time
+import requests
 
 from ring_doorbell.utils import _exists_cache, _save_cache, _read_cache
 
@@ -107,7 +107,7 @@ class Ring(object):
         # make a copy as we're mutating headers in the loop below
         # which would cause issues with _get_oauth_token()
         # which expects a non mutated HEADERS copy
-        modified_headers = HEADERS.copy() 
+        modified_headers = HEADERS.copy()
         while loop <= attempts:
             modified_headers['Authorization'] = \
                 'Bearer {}'.format(self._get_oauth_token())
@@ -125,7 +125,7 @@ class Ring(object):
                 raise
 
             if not req:
-                time.sleep(5) # add a pause or you'll get rate limited (429)
+                time.sleep(5)  # add a pause or you'll get rate limited (429)
                 continue
 
             # if token is expired, refresh credentials and try again

--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -176,6 +176,11 @@ class Ring(object):
             _LOGGER.debug("Not connected. Refreshing token...")
             self._authenticate()
 
+        # queries now need a bearer token or you'll get 401s
+        auth_header = {}
+        auth_header['Authorization'] = \
+                'Bearer {}'.format(self._get_oauth_token())
+
         response = None
         loop = 0
         while loop <= attempts:
@@ -193,12 +198,12 @@ class Ring(object):
             loop += 1
             try:
                 if method == 'GET':
-                    req = self.session.get((url), params=urlencode(params))
+                    req = self.session.get((url), params=urlencode(params), headers=auth_header)
                 elif method == 'PUT':
-                    req = self.session.put((url), params=urlencode(params))
+                    req = self.session.put((url), params=urlencode(params), headers=auth_header)
                 elif method == 'POST':
                     req = self.session.post(
-                        (url), params=urlencode(params), json=json)
+                        (url), params=urlencode(params), json=json, headers=auth_header)
 
                 if self.debug:
                     _LOGGER.debug("_query %s ret %s", loop, req.status_code)

--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -89,6 +89,7 @@ class Ring(object):
 
     def _get_oauth_token(self):
         """Return Oauth Bearer token."""
+        # this token should be cached / saved for later
         oauth_data = OAUTH_DATA.copy()
         oauth_data['username'] = self.username
         oauth_data['password'] = self.password

--- a/ring_doorbell/chime.py
+++ b/ring_doorbell/chime.py
@@ -23,9 +23,10 @@ class RingChime(RingGeneric):
     @property
     def model(self):
         """Return Ring device model name."""
+        # ignore R1705: Unnecessary "elif" after "return" (no-else-return)
         if self.kind in CHIME_KINDS:
             return 'Chime'
-        if self.kind in CHIME_PRO_KINDS:
+        elif self.kind in CHIME_PRO_KINDS:
             return 'Chime Pro'
         return None
 

--- a/ring_doorbell/chime.py
+++ b/ring_doorbell/chime.py
@@ -25,7 +25,7 @@ class RingChime(RingGeneric):
         """Return Ring device model name."""
         if self.kind in CHIME_KINDS:
             return 'Chime'
-        elif self.kind in CHIME_PRO_KINDS:
+        if self.kind in CHIME_PRO_KINDS:
             return 'Chime Pro'
         return None
 

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -5,7 +5,8 @@ import os
 from uuid import uuid4 as uuid
 HEADERS = {
     'Content-Type': 'application/x-www-form-urlencoded; charset: UTF-8',
-    'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 8.0.0; SM-G930F Build/R16NW)',
+    'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 9.0; SM-G850F Build'
+                  '"/LRX22G)',
     'Accept-Encoding': 'gzip, deflate'
 }
 

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -5,7 +5,7 @@ import os
 from uuid import uuid4 as uuid
 HEADERS = {
     'Content-Type': 'application/x-www-form-urlencoded; charset: UTF-8',
-    'User-Agent': 'Dalvik/1.6.0 (Linux; Android 4.4.4; Build/KTU84Q)',
+    'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 8.0.0; SM-G930F Build/R16NW)',
     'Accept-Encoding': 'gzip, deflate'
 }
 

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -36,11 +36,11 @@ class RingDoorBell(RingGeneric):
         """Return Ring device model name."""
         if self.kind in DOORBELL_KINDS:
             return 'Doorbell'
-        elif self.kind in DOORBELL_2_KINDS:
+        if self.kind in DOORBELL_2_KINDS:
             return 'Doorbell 2'
-        elif self.kind in DOORBELL_PRO_KINDS:
+        if self.kind in DOORBELL_PRO_KINDS:
             return 'Doorbell Pro'
-        elif self.kind in DOORBELL_ELITE_KINDS:
+        if self.kind in DOORBELL_ELITE_KINDS:
             return 'Doorbell Elite'
         return None
 
@@ -49,7 +49,7 @@ class RingDoorBell(RingGeneric):
         if capability == 'battery':
             return self.kind in (DOORBELL_KINDS +
                                  DOORBELL_2_KINDS)
-        elif capability == 'volume':
+        if capability == 'volume':
             return True
         return False
 

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -34,22 +34,24 @@ class RingDoorBell(RingGeneric):
     @property
     def model(self):
         """Return Ring device model name."""
+        # ignore R1705: Unnecessary "elif" after "return" (no-else-return)
         if self.kind in DOORBELL_KINDS:
             return 'Doorbell'
-        if self.kind in DOORBELL_2_KINDS:
+        elif self.kind in DOORBELL_2_KINDS:
             return 'Doorbell 2'
-        if self.kind in DOORBELL_PRO_KINDS:
+        elif self.kind in DOORBELL_PRO_KINDS:
             return 'Doorbell Pro'
-        if self.kind in DOORBELL_ELITE_KINDS:
+        elif self.kind in DOORBELL_ELITE_KINDS:
             return 'Doorbell Elite'
         return None
 
     def has_capability(self, capability):
         """Return if device has specific capability."""
+        # ignore R1705: Unnecessary "elif" after "return" (no-else-return)
         if capability == 'battery':
             return self.kind in (DOORBELL_KINDS +
                                  DOORBELL_2_KINDS)
-        if capability == 'volume':
+        elif capability == 'volume':
             return True
         return False
 

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -27,17 +27,17 @@ class RingStickUpCam(RingDoorBell):
         """Return Ring device model name."""
         if self.kind in FLOODLIGHT_CAM_KINDS:
             return 'Floodlight Cam'
-        elif self.kind in SPOTLIGHT_CAM_BATTERY_KINDS:
+        if self.kind in SPOTLIGHT_CAM_BATTERY_KINDS:
             return 'Spotlight Cam {}'.format(
                 self._attrs.get('ring_cam_setup_flow', 'battery').title())
-        elif self.kind in SPOTLIGHT_CAM_WIRED_KINDS:
+        if self.kind in SPOTLIGHT_CAM_WIRED_KINDS:
             return 'Spotlight Cam {}'.format(
                 self._attrs.get('ring_cam_setup_flow', 'wired').title())
-        elif self.kind in STICKUP_CAM_KINDS:
+        if self.kind in STICKUP_CAM_KINDS:
             return 'Stick Up Cam'
-        elif self.kind in STICKUP_CAM_BATTERY_KINDS:
+        if self.kind in STICKUP_CAM_BATTERY_KINDS:
             return 'Stick Up Cam Battery'
-        elif self.kind in STICKUP_CAM_WIRED_KINDS:
+        if self.kind in STICKUP_CAM_WIRED_KINDS:
             return 'Stick Up Cam Wired'
         return None
 
@@ -47,11 +47,11 @@ class RingStickUpCam(RingDoorBell):
             return self.kind in (SPOTLIGHT_CAM_BATTERY_KINDS +
                                  STICKUP_CAM_KINDS +
                                  STICKUP_CAM_BATTERY_KINDS)
-        elif capability == 'light':
+        if capability == 'light':
             return self.kind in (FLOODLIGHT_CAM_KINDS +
                                  SPOTLIGHT_CAM_BATTERY_KINDS +
                                  SPOTLIGHT_CAM_WIRED_KINDS)
-        elif capability == 'siren':
+        if capability == 'siren':
             return self.kind in (FLOODLIGHT_CAM_KINDS +
                                  SPOTLIGHT_CAM_BATTERY_KINDS +
                                  SPOTLIGHT_CAM_WIRED_KINDS +

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -25,33 +25,35 @@ class RingStickUpCam(RingDoorBell):
     @property
     def model(self):
         """Return Ring device model name."""
+        # ignore R1705: Unnecessary "elif" after "return" (no-else-return)
         if self.kind in FLOODLIGHT_CAM_KINDS:
             return 'Floodlight Cam'
-        if self.kind in SPOTLIGHT_CAM_BATTERY_KINDS:
+        elif self.kind in SPOTLIGHT_CAM_BATTERY_KINDS:
             return 'Spotlight Cam {}'.format(
                 self._attrs.get('ring_cam_setup_flow', 'battery').title())
-        if self.kind in SPOTLIGHT_CAM_WIRED_KINDS:
+        elif self.kind in SPOTLIGHT_CAM_WIRED_KINDS:
             return 'Spotlight Cam {}'.format(
                 self._attrs.get('ring_cam_setup_flow', 'wired').title())
-        if self.kind in STICKUP_CAM_KINDS:
+        elif self.kind in STICKUP_CAM_KINDS:
             return 'Stick Up Cam'
-        if self.kind in STICKUP_CAM_BATTERY_KINDS:
+        elif self.kind in STICKUP_CAM_BATTERY_KINDS:
             return 'Stick Up Cam Battery'
-        if self.kind in STICKUP_CAM_WIRED_KINDS:
+        elif self.kind in STICKUP_CAM_WIRED_KINDS:
             return 'Stick Up Cam Wired'
         return None
 
     def has_capability(self, capability):
         """Return if device has specific capability."""
+        # ignore R1705: Unnecessary "elif" after "return" (no-else-return)
         if capability == 'battery':
             return self.kind in (SPOTLIGHT_CAM_BATTERY_KINDS +
                                  STICKUP_CAM_KINDS +
                                  STICKUP_CAM_BATTERY_KINDS)
-        if capability == 'light':
+        elif capability == 'light':
             return self.kind in (FLOODLIGHT_CAM_KINDS +
                                  SPOTLIGHT_CAM_BATTERY_KINDS +
                                  SPOTLIGHT_CAM_WIRED_KINDS)
-        if capability == 'siren':
+        elif capability == 'siren':
             return self.kind in (FLOODLIGHT_CAM_KINDS +
                                  SPOTLIGHT_CAM_BATTERY_KINDS +
                                  SPOTLIGHT_CAM_WIRED_KINDS +

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Python Ring Door Bell setup script."""
 from setuptools import setup
 
-_VERSION = '0.2.5'
+_VERSION = '0.2.6'
 
 
 def readme():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Python Ring Door Bell setup script."""
 from setuptools import setup
 
-_VERSION = '0.2.4'
+_VERSION = '0.2.5'
 
 
 def readme():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Python Ring Door Bell setup script."""
 from setuptools import setup
 
-_VERSION = '0.2.6'
+_VERSION = '0.2.7'
 
 
 def readme():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Python Ring Door Bell setup script."""
 from setuptools import setup
 
-_VERSION = '0.2.7'
+_VERSION = '0.2.5'
 
 
 def readme():

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -134,7 +134,7 @@ class TestRing(RingUnitTestBase):
     @requests_mock.Mocker()
     def test_doorbell_alerts(self, mock):
         mock.post('https://oauth.ring.com/oauth/token',
-                 text=load_fixture('ring_oauth.json'))
+                  text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
                  text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/dings/active',

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -134,9 +134,9 @@ class TestRing(RingUnitTestBase):
     @requests_mock.Mocker()
     def test_doorbell_alerts(self, mock):
         mock.post('https://oauth.ring.com/oauth/token',
-                  text=load_fixture('ring_oauth.json'))
+                 text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
-                  text=load_fixture('ring_devices.json'))
+                 text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/dings/active',
                  text=load_fixture('ring_ding_active.json'))
         mock.get('https://api.ring.com/clients_api/doorbots/987652/health',

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -12,6 +12,8 @@ class TestRing(RingUnitTestBase):
     @requests_mock.Mocker()
     def test_basic_attributes(self, mock):
         """Test the Ring class and methods."""
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
                  text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/chimes/999999/health',
@@ -34,6 +36,8 @@ class TestRing(RingUnitTestBase):
     @requests_mock.Mocker()
     def test_chime_attributes(self, mock):
         """Test the Ring Chime class and methods."""
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
                  text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/chimes/999999/health',
@@ -58,6 +62,8 @@ class TestRing(RingUnitTestBase):
 
     @requests_mock.Mocker()
     def test_doorbell_attributes(self, mock):
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
                  text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/doorbots/987652/history',
@@ -99,6 +105,8 @@ class TestRing(RingUnitTestBase):
 
     @requests_mock.Mocker()
     def test_shared_doorbell_attributes(self, mock):
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
                  text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/doorbots/987652/history',
@@ -125,8 +133,10 @@ class TestRing(RingUnitTestBase):
 
     @requests_mock.Mocker()
     def test_doorbell_alerts(self, mock):
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
-                 text=load_fixture('ring_devices.json'))
+                  text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/dings/active',
                  text=load_fixture('ring_ding_active.json'))
         mock.get('https://api.ring.com/clients_api/doorbots/987652/health',
@@ -148,6 +158,8 @@ class TestRing(RingUnitTestBase):
 
     @requests_mock.Mocker()
     def test_stickup_cam_attributes(self, mock):
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
                  text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/doorbots/987652/health',
@@ -164,6 +176,8 @@ class TestRing(RingUnitTestBase):
 
     @requests_mock.Mocker()
     def test_stickup_cam_controls(self, mock):
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',
                  text=load_fixture('ring_devices.json'))
         mock.get('https://api.ring.com/clients_api/doorbots/987652/health',


### PR DESCRIPTION
Fixes #142 #121 

- Update an old user agent in header that was blocked so oauth token could not be retrieved
- OAuth bearer token must be in get calls (haven't tested posts/puts)
- HTTP 429 (rate limited) could possibly still occur due to the amount of retries and loops in the component. I think ring have enabled extra restrictions.
- linter fixes

Not done:
- oauth token should be cached rather than retrieved per call. This could potentially appear as an error in future.
- HTTP 429 check rather than adding a sleep() between retries