### PR TITLE
Increased timeout from 5 to 10 seconds

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -19,7 +19,7 @@ class OAuth:
 RETRY_TOKEN = 3
 
 # timeout for HTTP requests
-TIMEOUT = 5
+TIMEOUT = 10
 
 # longer default timeout for recording downloads - typical video file sizes
 # are ~12 MB and empirical testing reveals a ~20 second download time over a


### PR DESCRIPTION
To prevent time-out with the home-assistant ring component..
See also https://github.com/home-assistant/home-assistant/pull/30666