### PR TITLE
Removed otp_callback

### DIFF
--- a/ring_doorbell/auth.py
+++ b/ring_doorbell/auth.py
@@ -3,8 +3,7 @@
 """Python Ring Auth Class."""
 from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2 import (
-    LegacyApplicationClient, TokenExpiredError,
-    MissingTokenError)
+    LegacyApplicationClient, TokenExpiredError)
 from ring_doorbell.const import OAuth, API_VERSION, TIMEOUT
 
 
@@ -23,23 +22,8 @@ class Auth:
             token=token
         )
 
-    def fetch_token(self, username, password, otp_callback=None):
+    def fetch_token(self, username, password, otp_code=None):
         """Initial token fetch with username/password & 2FA
-        :type username: str
-        :type password: str
-        :type otp_callback: Callable[[], str] One Time Password callback.
-        """
-        try:
-            return self.__fetch_token(username, password)
-
-        except MissingTokenError:
-            if not otp_callback:
-                raise
-
-            return self.__fetch_token(username, password, otp_callback())
-
-    def __fetch_token(self, username, password, otp_code=None):
-        """Private fetch token method
         :type username: str
         :type password: str
         :type otp_code: str

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from ring_doorbell import Ring, Auth
+from oauthlib.oauth2 import MissingTokenError
 
 
 cache_file = Path('test_token.cache')
@@ -23,7 +24,10 @@ def main():
         username = input("Username: ")
         password = input("Password: ")
         auth = Auth(None, token_updated)
-        auth.fetch_token(username, password, otp_callback)
+        try:
+            auth.fetch_token(username, password)
+        except MissingTokenError:
+            auth.fetch_token(username, password, otp_callback())
 
     ring = Ring(auth)
     print(ring.devices)


### PR DESCRIPTION
Removed the otp_callback and made is otp_code as a str.
Moved the private fetch_token logic into the public method, removed private method.  
MissingTokenError to be caught by calling client.

@balloob I also have an edit for the update-ring branch in HA, I can submit a PR on this as well.  

https://github.com/steve-gombos/home-assistant/tree/upgrade-ring