### PR TITLE
Return None if no battery installed

### DIFF
--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -85,6 +85,12 @@ class RingDoorBell(RingGeneric):
     @property
     def battery_life(self):
         """Return battery life."""
+        if (
+            self._attrs.get("battery_life") is None
+            and self._attrs.get("battery_life_2") is None
+        ):
+            return None
+
         value = 0
         if "battery_life_2" in self._attrs:
             # Camera has two battery bays
@@ -95,12 +101,13 @@ class RingDoorBell(RingGeneric):
                 # Bay 2
                 value += int(self._attrs.get("battery_life_2"))
             return value
+
         # Camera has a single battery bay
         # Latest stickup cam can be externally powered
-        if self._attrs.get("battery_life") is not None:
-            value = int(self._attrs.get("battery_life"))
-            if value and value > 100:
-                value = 100
+        value = int(self._attrs.get("battery_life"))
+        if value and value > 100:
+            value = 100
+
         return value
 
     @property


### PR DESCRIPTION
If a camera has no battery, return `None` instead of 0 to indicate that there is no battery available.

btw, right now battery_life 1 and 2 are summed if there are 2 battery bays. But shouldn't the result then also be divided by 2? So 2 full batteries is 100, while now it would be 200 ? 