### PR TITLE
Drop python 2.7/3.5. Updated readme and test.py examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 matrix:
   fast_finish: true
   include:
-    - python: "3.5"
-      env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 matrix:
   fast_finish: true
   include:
-    - python: "2.7"
-      env: TOXENV=py27
     - python: "3.5"
       env: TOXENV=py35
     - python: "3.6"

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Initializing your Ring object
     auth.fetch_token(username, password)
     ring = Ring(auth)
     ring.update_data()
+    devices = ring.devices()
 
     pprint(ring.session['profile'])
 
@@ -66,6 +67,7 @@ Playing with the attributes and functions
 -----------------------------------------
 .. code-block:: python
 
+    devices = ring.devices()
     for dev in list(devices['stickup_cams'] + devices['chimes'] + devices['doorbots']):
         dev.update_health_data()
         print('Address:    %s' % dev.address)
@@ -95,6 +97,7 @@ Showing door bell events
 ------------------------
 .. code-block:: python
 
+    devices = ring.devices()
     for doorbell in devices['doorbots']:
 
         # listing the last 15 events of any kind
@@ -113,6 +116,7 @@ Downloading the last video triggered by ding
 --------------------------------------------
 .. code-block:: python
 
+    devices = ring.devices()
     doorbell = devices['doorbots'][0]
     doorbell.recording_download(
         doorbell.history(limit=100, kind='ding')[0]['id'],

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Ring Door Bell
     :target: https://pypi.python.org/pypi/ring-doorbell
 
 
-Python Ring Door Bell is a library written in Python 3x
+Python Ring Door Bell is a library written for Python 3.6+
 that exposes the Ring.com devices as Python objects.
 
 *Currently Ring.com does not provide an official API. The results of this project are merely from reverse engineering.*

--- a/README.rst
+++ b/README.rst
@@ -58,17 +58,16 @@ Listing devices linked to your account
 .. code-block:: python
 
     # All devices
-    myring.devices()
+    ring.devices()
     {'chimes': [<RingChime: Downstairs>],
-    'doorbells': [<RingDoorBell: Front Door>]}
+    'doorbots': [<RingDoorBell: Front Door>]}
 
 Playing with the attributes and functions
 -----------------------------------------
 .. code-block:: python
 
-    for dev in list(myring.stickup_cams + myring.chimes + myring.doorbells):
+    for dev in list(devices['stickup_cams'] + devices['chimes'] + devices['doorbots']):
         dev.update_health_data()
-        print('Account ID: %s' % dev.account_id)
         print('Address:    %s' % dev.address)
         print('Family:     %s' % dev.family)
         print('ID:         %s' % dev.id)
@@ -96,7 +95,7 @@ Showing door bell events
 ------------------------
 .. code-block:: python
 
-    for doorbell in myring.doorbells:
+    for doorbell in devices['doorbots']:
 
         # listing the last 15 events of any kind
         for event in doorbell.history(limit=15):
@@ -114,10 +113,10 @@ Downloading the last video triggered by ding
 --------------------------------------------
 .. code-block:: python
 
-    doorbell = myring.doorbells[0]
+    doorbell = devices['doorbots'][0]
     doorbell.recording_download(
         doorbell.history(limit=100, kind='ding')[0]['id'],
-                         filename='/home/user/last_ding.mp4',
+                         filename='last_ding.mp4',
                          override=True)
 
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Ring Door Bell
     :target: https://pypi.python.org/pypi/ring-doorbell
 
 
-Python Ring Door Bell is a library written in Python 2.7/3x
+Python Ring Door Bell is a library written in Python 3x
 that exposes the Ring.com devices as Python objects.
 
 *Currently Ring.com does not provide an official API. The results of this project are merely from reverse engineering.*

--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,21 @@ Listing devices linked to your account
 .. code-block:: python
 
     # All devices
-    ring.devices()
+    devices = ring.devices()
     {'chimes': [<RingChime: Downstairs>],
     'doorbots': [<RingDoorBell: Front Door>]}
+
+    # All doorbells
+    doorbells = devices['doorbots']
+    [<RingDoorBell: Front Door>]
+
+    # All chimes
+    chimes = devices['chimes']
+    [<RingChime: Downstairs>]
+
+    # All stickup cams
+    stickup_cams = devices['stickup_cams']
+    [<RingStickUpCam: Driveway>]
 
 Playing with the attributes and functions
 -----------------------------------------

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -6,4 +6,3 @@ pytest
 pytest-cov
 requests_mock
 tox
-pathlib

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -6,3 +6,4 @@ pytest
 pytest-cov
 requests_mock
 tox
+pathlib

--- a/scripts/ringcli.py
+++ b/scripts/ringcli.py
@@ -2,9 +2,12 @@
 # vim:sw=4:ts=4:et
 # Many thanks to @troopermax <https://github.com/troopermax>
 
+import json
 import getpass
 import argparse
-from ring_doorbell import Ring
+from pathlib import Path
+from ring_doorbell import Ring, Auth
+from oauthlib.oauth2 import MissingTokenError
 
 
 def _header():
@@ -13,95 +16,106 @@ def _header():
 
 
 def _bar():
-    print('---------------------------------')
+    print("---------------------------------")
 
 
-def get_username():
-    try:
-        username = raw_input("Username: ")
-    except NameError:
-        username = input("Username: ")
-    return username
+cache_file = Path("test_token.cache")
+
+
+def token_updated(token):
+    cache_file.write_text(json.dumps(token))
 
 
 def _format_filename(event):
     if not isinstance(event, dict):
         return
 
-    if event['answered']:
-        answered_status = 'answered'
+    if event["answered"]:
+        answered_status = "answered"
     else:
-        answered_status = 'not_answered'
+        answered_status = "not_answered"
 
-    filename = "{}_{}_{}_{}".format(event['created_at'],
-                                    event['kind'],
-                                    answered_status,
-                                    event['id'])
+    filename = "{}_{}_{}_{}".format(
+        event["created_at"], event["kind"], answered_status, event["id"]
+    )
 
-    filename = filename.replace(' ', '_').replace(':', '.')+'.mp4'
+    filename = filename.replace(" ", "_").replace(":", ".") + ".mp4"
     return filename
 
 
 def main():
 
     parser = argparse.ArgumentParser(
-            description='Ring Doorbell',
-            epilog='https://github.com/tchellomello/python-ring-doorbell',
-            formatter_class=argparse.RawDescriptionHelpFormatter)
+        description="Ring Doorbell",
+        epilog="https://github.com/tchellomello/python-ring-doorbell",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
-    parser.add_argument('-u',
-                        '--username',
-                        dest='username',
-                        type=str,
-                        help='username for Ring account')
+    parser.add_argument(
+        "-u", "--username", dest="username", type=str, help="username for Ring account"
+    )
 
-    parser.add_argument('-p',
-                        '--password',
-                        type=str,
-                        dest='password',
-                        help='username for Ring account')
+    parser.add_argument(
+        "-p", "--password", type=str, dest="password", help="username for Ring account"
+    )
 
-    parser.add_argument('--count',
-                        action='store_true',
-                        default=False,
-                        help='count the number of videos on your Ring account')
+    parser.add_argument(
+        "--count",
+        action="store_true",
+        default=False,
+        help="count the number of videos on your Ring account",
+    )
 
-    parser.add_argument('--download-all',
-                        action='store_true',
-                        default=False,
-                        help='download all videos on your Ring account')
+    parser.add_argument(
+        "--download-all",
+        action="store_true",
+        default=False,
+        help="download all videos on your Ring account",
+    )
 
     args = parser.parse_args()
     _header()
 
-    if not args.username:
-        args.username = get_username()
-
-    if not args.password:
-        args.password = getpass.getpass("Password: ")
-
     # connect to Ring account
-    myring = Ring(args.username, args.password)
-    doorbell = myring.doorbells[0]
+    if cache_file.is_file():
+        auth = Auth("RingCLI/0.6", json.loads(cache_file.read_text()), token_updated)
+    else:
+        if not args.username:
+            args.username = input("Username: ")
+
+        if not args.password:
+            args.password = getpass.getpass("Password: ")
+
+        auth = Auth("RingCLI/0.6", None, token_updated)
+        try:
+            auth.fetch_token(args.username, args.password)
+        except MissingTokenError:
+            auth.fetch_token(args.username, args.password, input("2FA Code: "))
+
+    ring = Ring(auth)
+    ring.update_data()
+    devices = ring.devices()
+    doorbell = devices["doorbots"][0]
 
     _bar()
 
     if args.count:
-        print("\tCounting videos linked on your Ring account.\n" +
-              "\tThis may take some time....\n")
+        print(
+            "\tCounting videos linked on your Ring account.\n"
+            + "\tThis may take some time....\n"
+        )
 
         events = []
         counter = 0
         history = doorbell.history(limit=100)
-        while (len(history) > 0):
+        while len(history) > 0:
             events += history
             counter += len(history)
-            history = doorbell.history(older_than=history[-1]['id'])
+            history = doorbell.history(older_than=history[-1]["id"])
 
-        motion = len([m['kind'] for m in events if m['kind'] == 'motion'])
-        ding = len([m['kind'] for m in events if m['kind'] == 'ding'])
-        on_demand = \
-            len([m['kind'] for m in events if m['kind'] == 'on_demand'])
+        motion = len([m["kind"] for m in events if m["kind"] == "motion"])
+        ding = len([m["kind"] for m in events if m["kind"] == "ding"])
+        on_demand = len([m["kind"] for m in events if m["kind"] == "on_demand"])
 
         print("\tTotal videos: {}".format(counter))
         print("\tDing triggered: {}".format(ding))
@@ -111,43 +125,44 @@ def main():
         # already have all events in memory
         if args.download_all:
             counter = 0
-            print("\tDownloading all videos linked on your Ring account.\n" +
-                  "\tThis may take some time....\n")
+            print(
+                "\tDownloading all videos linked on your Ring account.\n"
+                + "\tThis may take some time....\n"
+            )
 
             for event in events:
                 counter += 1
                 filename = _format_filename(event)
-                print("\t{}/{} Downloading {}".format(counter,
-                                                      len(events),
-                                                      filename))
+                print("\t{}/{} Downloading {}".format(counter, len(events), filename))
 
-                doorbell.recording_download(event['id'],
-                                            filename=filename,
-                                            override=False)
+                doorbell.recording_download(
+                    event["id"], filename=filename, override=False
+                )
 
     if args.download_all and not args.count:
-        print("\tDownloading all videos linked on your Ring account.\n" +
-              "\tThis may take some time....\n")
+        print(
+            "\tDownloading all videos linked on your Ring account.\n"
+            + "\tThis may take some time....\n"
+        )
         history = doorbell.history(limit=100)
 
-        while (len(history) > 0):
-            print("\tProcessing and downloading the next" +
-                  " videos".format(len(history)))
+        while len(history) > 0:
+            print(
+                "\tProcessing and downloading the next" + " videos".format(len(history))
+            )
 
             counter = 0
             for event in history:
                 counter += 1
                 filename = _format_filename(event)
-                print("\t{}/{} Downloading {}".format(counter,
-                                                      len(history),
-                                                      filename))
+                print("\t{}/{} Downloading {}".format(counter, len(history), filename))
 
-                doorbell.recording_download(event['id'],
-                                            filename=filename,
-                                            override=False)
+                doorbell.recording_download(
+                    event["id"], filename=filename, override=False
+                )
 
-            history = doorbell.history(limit=100, older_than=history[-1]['id'])
+            history = doorbell.history(limit=100, older_than=history[-1]["id"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ setup(
         'GNU Lesser General Public License v3 or later (LGPLv3+)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Home Automation',

--- a/test.py
+++ b/test.py
@@ -20,7 +20,7 @@ def otp_callback():
 def main():
     if cache_file.is_file():
         auth = Auth(
-            "HomeAssistant/0.105.0dev0",
+            "MyProject/1.0",
             json.loads(cache_file.read_text()),
             token_updated,
         )

--- a/test.py
+++ b/test.py
@@ -27,7 +27,7 @@ def main():
     else:
         username = input("Username: ")
         password = input("Password: ")
-        auth = Auth("HomeAssistant/0.105.0dev0", None, token_updated)
+        auth = Auth("MyProject/1.0", None, token_updated)
         try:
             auth.fetch_token(username, password)
         except MissingTokenError:

--- a/test.py
+++ b/test.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from pprint import pprint
 
 from ring_doorbell import Ring, Auth
 from oauthlib.oauth2 import MissingTokenError
@@ -28,7 +27,7 @@ def main():
     else:
         username = input("Username: ")
         password = input("Password: ")
-        auth = Auth(None, token_updated)
+        auth = Auth("HomeAssistant/0.105.0dev0", None, token_updated)
         try:
             auth.fetch_token(username, password)
         except MissingTokenError:
@@ -36,10 +35,10 @@ def main():
 
     ring = Ring(auth)
     ring.update_data()
-
+    devices = ring.devices()
     print(f"Hello {ring.session['profile']['first_name']}")
     print()
-    pprint(ring.devices_data)
+    print(devices)
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 import json
+import getpass
 from pathlib import Path
 
 from ring_doorbell import Ring, Auth
@@ -19,10 +20,10 @@ def otp_callback():
 
 def main():
     if cache_file.is_file():
-        auth = Auth("MyProject/1.0", json.loads(cache_file.read_text()), token_updated,)
+        auth = Auth("MyProject/1.0", json.loads(cache_file.read_text()), token_updated)
     else:
         username = input("Username: ")
-        password = input("Password: ")
+        password = getpass.getpass("Password: ")
         auth = Auth("MyProject/1.0", None, token_updated)
         try:
             auth.fetch_token(username, password)

--- a/test.py
+++ b/test.py
@@ -36,8 +36,6 @@ def main():
     ring = Ring(auth)
     ring.update_data()
     devices = ring.devices()
-    print(f"Hello {ring.session['profile']['first_name']}")
-    print()
     print(devices)
 
 

--- a/test.py
+++ b/test.py
@@ -32,8 +32,17 @@ def main():
 
     ring = Ring(auth)
     ring.update_data()
+
     devices = ring.devices()
     print(devices)
+
+    doorbells = devices["doorbots"]
+    chimes = devices["chimes"]
+    stickup_cams = devices["stickup_cams"]
+
+    print(doorbells)
+    print(chimes)
+    print(stickup_cams)
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -19,11 +19,7 @@ def otp_callback():
 
 def main():
     if cache_file.is_file():
-        auth = Auth(
-            "MyProject/1.0",
-            json.loads(cache_file.read_text()),
-            token_updated,
-        )
+        auth = Auth("MyProject/1.0", json.loads(cache_file.read_text()), token_updated,)
     else:
         username = input("Username: ")
         password = input("Password: ")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, lint
+envlist = py36, py37, lint
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, lint
+envlist = py35, py36, py37, lint
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,6 @@ deps =
 ignore_errors = True
 commands =
      pip3 install black
-     flake8 ring_doorbell tests test.py
+     flake8 ring_doorbell tests test.py scripts
      pylint ring_doorbell
-     black --check ring_doorbell tests test.py
+     black --check ring_doorbell tests test.py scripts


### PR DESCRIPTION
- Removed python 2.7 and python 3.5.  Min python 3.6+.

- Updated the README (#188 and #190)

- Updated test.py examples for the data refactor that @balloob had previously done. (#186 and #189) 