### PR TITLE
Fix get snapshot based on comments

### DIFF
--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -424,13 +424,13 @@ class RingDoorBell(RingGeneric):
         """Take a snapshot and download it"""
         url = SNAPSHOT_TIMESTAMP_ENDPOINT
         payload = {"doorbot_ids": [self._attrs.get("id")]}
-        self._ring.query(url)
+        self._ring.query(url, method="POST", json=payload)
         request_time = time.time()
         for _ in range(retries):
             time.sleep(delay)
             response = self._ring.query(url, method="POST", json=payload).json()
             if response["timestamps"][0]["timestamp"] / 1000 > request_time:
                 return self._ring.query(
-                    SNAPSHOT_ENDPOINT.format(self._attrs.get("id"))
+                    SNAPSHOT_ENDPOINT.format(self._attrs.get("id"), raw=True)
                 ).content
         return False


### PR DESCRIPTION
Saw some older comments on how to fix `get_snapshot` gave it a spin myself with some modified code in HA and to my surprise it worked.  It does seem like we get undesired results at times but the snapshots do indeed come through.

https://github.com/tchellomello/python-ring-doorbell/issues/147#issuecomment-569485663

https://github.com/tchellomello/python-ring-doorbell/issues/178#issuecomment-583767379

https://github.com/tchellomello/python-ring-doorbell/issues/181#issuecomment-574710982

Should also close: #124 i think too

Code I used in HA for testing `homeassistant/components/ring/camera.py`

Changed lines 111-113 from:

```
        image = await asyncio.shield(
            ffmpeg.get_image(self._video_url, output_format=IMAGE_JPEG,)
        )
```

to

```
image = self._device.get_snapshot()
```

Results in, snapshots taken when there is no motion! (Note: I have yet to test this with a person at the front door lol):
![image](https://user-images.githubusercontent.com/1634145/74909001-2d4fcf80-536c-11ea-8b25-e52e3a4d07bc.png)

![image](https://user-images.githubusercontent.com/1634145/74909592-7d7b6180-536d-11ea-9484-e4ede634f9b9.png)


Following errors were experienced during testing on my 4 devices.  Important to note that these errors show up for both unsupported devices (i.e. devices without snapshot feature in Ring app) and also show up when I take back to back snapshots in between supported devices.  There seems to be a 1-3 minute period (or longer) where the errors show up and after waiting the command works again:

```
2020-02-19 22:54:10 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/mnt/c/dev/home-assistant/venv/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/mnt/c/dev/home-assistant/venv/lib/python3.7/site-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/mnt/c/dev/home-assistant/venv/lib/python3.7/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/mnt/c/dev/home-assistant/homeassistant/components/http/real_ip.py", line 39, in real_ip_middleware
    return await handler(request)
  File "/mnt/c/dev/home-assistant/homeassistant/components/http/ban.py", line 72, in ban_middleware
    return await handler(request)
  File "/mnt/c/dev/home-assistant/homeassistant/components/http/auth.py", line 135, in auth_middleware
    return await handler(request)
  File "/mnt/c/dev/home-assistant/homeassistant/components/http/view.py", line 123, in handle
    result = await result
  File "/mnt/c/dev/home-assistant/homeassistant/components/camera/__init__.py", line 485, in get
    return await self.handle(request, camera)
  File "/mnt/c/dev/home-assistant/homeassistant/components/camera/__init__.py", line 502, in handle
    image = await camera.async_camera_image()
  File "/mnt/c/dev/home-assistant/homeassistant/components/ring/camera.py", line 111, in async_camera_image
    image = self._device.get_snapshot()
  File "/mnt/c/dev/home-assistant/venv/lib/python3.7/site-packages/ring_doorbell/doorbot.py", line 418, in get_snapshot
    if response["timestamps"][0]["timestamp"] / 1000 > request_time:
IndexError: list index out of range
2020-02-19 22:54:17 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection.139829777926968] a bytes-like object is required, not 'bool'
Traceback (most recent call last):
  File "/mnt/c/dev/home-assistant/homeassistant/components/websocket_api/commands.py", line 134, in handle_call_service
    connection.context(msg),
  File "/mnt/c/dev/home-assistant/homeassistant/core.py", line 1230, in async_call
    await asyncio.shield(self._execute_service(handler, service_call))
  File "/mnt/c/dev/home-assistant/homeassistant/core.py", line 1253, in _execute_service
    await handler.func(service_call)
  File "/mnt/c/dev/home-assistant/homeassistant/helpers/entity_component.py", line 198, in handle_service
    self._platforms.values(), func, call, required_features
  File "/mnt/c/dev/home-assistant/homeassistant/helpers/service.py", line 402, in entity_service_call
    future.result()  # pop exception if have
  File "/mnt/c/dev/home-assistant/homeassistant/helpers/entity.py", line 590, in async_request_call
    await coro
  File "/mnt/c/dev/home-assistant/homeassistant/helpers/service.py", line 433, in _handle_entity_call
    await result
  File "/mnt/c/dev/home-assistant/homeassistant/components/camera/__init__.py", line 648, in async_handle_snapshot_service
    await hass.async_add_executor_job(_write_image, snapshot_file, image)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/mnt/c/dev/home-assistant/homeassistant/components/camera/__init__.py", line 645, in _write_image
    img_file.write(image_data)
TypeError: a bytes-like object is required, not 'bool'
```

Curious to see if others get the same results too. 