### PR TITLE
Fixed RingDoorBell.get_snapshot() and added download

### DIFF
--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -427,7 +427,7 @@ class RingDoorBell(RingGeneric):
         """Return connection status."""
         return self._attrs.get("alerts").get("connection")
 
-    def get_snapshot(self, retries=3, delay=1, filename="snapshot.jpg",):
+    def get_snapshot(self, retries=3, delay=1, filename="snapshot.jpg"):
         """Take a snapshot and download it"""
         url = SNAPSHOT_TIMESTAMP_ENDPOINT
         payload = {"doorbot_ids": [self._attrs.get("id")]}

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -420,7 +420,7 @@ class RingDoorBell(RingGeneric):
         """Return connection status."""
         return self._attrs.get("alerts").get("connection")
 
-    def get_snapshot(self, retries=3, delay=1):
+    def get_snapshot(self, filename="snapshot.jpg", retries=3, delay=1):
         """Take a snapshot and download it"""
         url = SNAPSHOT_TIMESTAMP_ENDPOINT
         payload = {"doorbot_ids": [self._attrs.get("id")]}
@@ -430,7 +430,10 @@ class RingDoorBell(RingGeneric):
             time.sleep(delay)
             response = self._ring.query(url, method="POST", json=payload).json()
             if response["timestamps"][0]["timestamp"] / 1000 > request_time:
-                return self._ring.query(
+                snapshot = self._ring.query(
                     SNAPSHOT_ENDPOINT.format(self._attrs.get("id"))
                 ).content
+                with open(filename, "wb") as jpg:
+                    jpg.write(snapshot)
+                    return True
         return False

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -424,7 +424,7 @@ class RingDoorBell(RingGeneric):
         """Take a snapshot and download it"""
         url = SNAPSHOT_TIMESTAMP_ENDPOINT
         payload = {"doorbot_ids": [self._attrs.get("id")]}
-        self._ring.query(url)
+        self._ring.query(url, method="POST", json=payload)
         request_time = time.time()
         for _ in range(retries):
             time.sleep(delay)

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -420,7 +420,7 @@ class RingDoorBell(RingGeneric):
         """Return connection status."""
         return self._attrs.get("alerts").get("connection")
 
-    def get_snapshot(self, filename="snapshot.jpg", retries=3, delay=1):
+    def get_snapshot(self, retries=3, delay=1, filename="snapshot.jpg",):
         """Take a snapshot and download it"""
         url = SNAPSHOT_TIMESTAMP_ENDPOINT
         payload = {"doorbot_ids": [self._attrs.get("id")]}


### PR DESCRIPTION
Was getting 405 Client Error before because it looks like the endpoint (https://api.ring.com/clients_api/snapshots/timestamps?api_version=9) no longer accepts GET requests. Changed the initial snapshot request to a POST request to get it working.

Also added filename in arguements and download snapshot as jpg file to better match the function description """Take a snapshot and download it"""