### PR TITLE
Fix Build Errors

### DIFF
--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -43,7 +43,7 @@ class RingDoorBell(RingGeneric):
     """Implementation for Ring Doorbell."""
 
     def __init__(self, ring, device_id, shared=False):
-        super(RingDoorBell, self).__init__(ring, device_id)
+        super().__init__(ring, device_id)
         self.shared = shared
 
     @property

--- a/scripts/ringcli.py
+++ b/scripts/ringcli.py
@@ -148,7 +148,9 @@ def main():
 
         while len(history) > 0:
             print(
-                "\tProcessing and downloading the next" + " videos".format(len(history))
+                "\tProcessing and downloading the next "
+                + format(len(history))
+                + " videos"
             )
 
             counter = 0


### PR DESCRIPTION
Fixes bug in ringcli.py causing flake8 error
Fixes bug when running pylint test with the following error:
"************* Module ring_doorbell.doorbot
ring_doorbell\doorbot.py:46:8: R1725: Consider using Python 3 style super() without arguments (super-with-arguments)"