### PR TITLE
fix: prevent multiple device entries for "Python" in the Ring app when using this library

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -3,13 +3,13 @@
 """Python Ring Doorbell wrapper."""
 import logging
 from time import time
-from uuid import uuid4
 
 from .const import (
     API_URI,
     DEVICES_ENDPOINT,
     NEW_SESSION_ENDPOINT,
     DINGS_ENDPOINT,
+    POST_DATA,
 )
 from .auth import Auth  # noqa
 from .doorbot import RingDoorBell
@@ -54,24 +54,13 @@ class Ring(object):
 
     def create_session(self):
         """Create a new Ring session."""
+        session_post_data = POST_DATA
+        session_post_data['device[hardware_id]'] = self.auth.get_hardware_id()
+
         self.session = self.query(
             NEW_SESSION_ENDPOINT,
             method="POST",
-            data={
-                "api_version": "9",
-                "device[hardware_id]": uuid4().hex,
-                "device[os]": "android",
-                "device[app_brand]": "ring",
-                "device[metadata][device_model]": "KVM",
-                "device[metadata][device_name]": "Python",
-                "device[metadata][resolution]": "600x800",
-                "device[metadata][app_version]": "1.3.806",
-                "device[metadata][app_instalation_date]": "",
-                "device[metadata][manufacturer]": "Qemu",
-                "device[metadata][device_type]": "desktop",
-                "device[metadata][architecture]": "desktop",
-                "device[metadata][language]": "en",
-            },
+            data=session_post_data,
         ).json()
 
     def update_devices(self):

--- a/ring_doorbell/auth.py
+++ b/ring_doorbell/auth.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 # vim:sw=4:ts=4:et:
 """Python Ring Auth Class."""
+from uuid import uuid4 as uuid
 from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2 import LegacyApplicationClient, TokenExpiredError
 from ring_doorbell.const import OAuth, API_VERSION, TIMEOUT
@@ -9,12 +10,16 @@ from ring_doorbell.const import OAuth, API_VERSION, TIMEOUT
 class Auth:
     """A Python Auth class for Ring"""
 
-    def __init__(self, user_agent, token=None, token_updater=None):
+    def __init__(self, user_agent, token=None, token_updater=None, hardware_id=None):
         """
         :type token: Optional[Dict[str, str]]
         :type token_updater: Optional[Callable[[str], None]]
         """
         self.user_agent = user_agent
+
+        self.hardware_id = hardware_id
+        if self.hardware_id is None:
+            self.hardware_id = str(uuid())
 
         self.token_updater = token_updater
         self._oauth = OAuth2Session(
@@ -27,7 +32,11 @@ class Auth:
         :type password: str
         :type otp_code: str
         """
-        headers = {"User-Agent": self.user_agent}
+        headers = {
+                "User-Agent": self.user_agent,
+                "hardware_id": self.hardware_id
+        }
+
         if otp_code:
             headers["2fa-support"] = "true"
             headers["2fa-code"] = otp_code
@@ -55,6 +64,9 @@ class Auth:
             self.token_updater(token)
 
         return token
+
+    def get_hardware_id(self):
+        return self.hardware_id
 
     def query(
         self, url, method="GET", extra_params=None, data=None, json=None, timeout=None

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 # vim:sw=4:ts=4:et:
 """Constants."""
-from uuid import uuid4 as uuid
 
 
 class OAuth:
@@ -93,7 +92,6 @@ MSG_ALLOWED_VALUES = "Only the following values are allowed: {0}."
 
 POST_DATA = {
     "api_version": API_VERSION,
-    "device[hardware_id]": str(uuid()),
     "device[os]": "android",
     "device[app_brand]": "ring",
     "device[metadata][device_model]": "KVM",


### PR DESCRIPTION
This fixes the issue where Ring reports a new device for every session
made by this library.

By having the same hardware ID per request, and by also associating it
with the initial auth request, we can group all calls as a single "device"
within the ring app. This allows users to properly track account
usage.

The cause of this issue is the fact that right now, create_session() generates
a new UUID every time it's referenced. We also don't associate a hardware_id
with the fetch_token() currently, even though this is valid for that request. This
was found by looking through the source code of the node ring module at 
https://github.com/dgreif/ring/blob/master/api/rest-client.ts#L161