### PR TITLE
fix: attempt reauth on 401 when querying endpoints

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -81,7 +81,7 @@ class Ring(object):
         self, url, method="GET", extra_params=None, data=None, json=None, timeout=None
     ):
         """Query data from Ring API."""
-        return self.auth.query(
+        req = self.auth.query(
             API_URI + url,
             method=method,
             extra_params=extra_params,
@@ -89,6 +89,24 @@ class Ring(object):
             json=json,
             timeout=timeout,
         )
+
+        if req.status_code == 401:
+            _LOGGER.debug(
+                "%s response on query(), creating a new session.", req.status_code
+            )
+            self.create_session()
+            req = self.auth.query(
+                API_URI + url,
+                method=method,
+                extra_params=extra_params,
+                data=data,
+                json=json,
+                timeout=timeout,
+            )
+
+        req.raise_for_status()
+
+        return req
 
     def devices(self):
         """Get all devices."""

--- a/ring_doorbell/auth.py
+++ b/ring_doorbell/auth.py
@@ -98,6 +98,4 @@ class Auth:
             self._oauth.token = self.refresh_tokens()
             req = getattr(self._oauth, method.lower())(url, **kwargs)
 
-        req.raise_for_status()
-
         return req


### PR DESCRIPTION
Currently this library does not have any handling of unauthorized 
responses from the ring API. This implementation does a simple watch for 
a 401 response, and if once is received it will re-try the query after 
creating a new session. We also move raise_for_status() from auth.py to 
__init__.py, since all other classes call __init__.py when doing calls 
to the ring API and it needs to be relocated for this implementation to work.