### PR TITLE
[dist] Use GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  - push
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
+          - 3.7.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U tox coveralls
+      - name: Prepare toxenv
+        id: toxenv
+        run: |
+          if [[ '${{ matrix.python-version }}' == '3.6' ]]; then
+            echo "::set-output name=toxenv::py36"
+          elif [[ '${{ matrix.python-version }}' == '3.7' ]]; then
+            echo "::set-output name=toxenv::py37"
+          else
+            echo "::set-output name=toxenv::lint"
+          fi
+      - name: Test with tox
+        run: |
+          tox -e py
+        env:
+          TOXENV: ${{ steps.toxenv.outputs.toxenv }}
+      - name: Report to Coveralls
+        run: |
+          coveralls
+        if: ${{ success() }}


### PR DESCRIPTION
TravisCI.org is going away sometime soon. I think they want folks to use their ".com" product instead. This PR just swaps to using GitHub Actions as it's free for open-source and works pretty well.