### PR TITLE
Default to an empty list if no device_groups exist for the group location.

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -96,7 +96,7 @@ class Ring(object):
         locations.discard(None)
         for location in locations:
             data = self.query(GROUPS_ENDPOINT.format(location)).json()
-            for group in data["device_groups"]:
+            for group in data.get("device_groups") or []:
                 self.groups_data[group["device_group_id"]] = group
 
     def query(


### PR DESCRIPTION
Looks like under certain circumstances (in my case that is!) the response from the `/groups/v1/locations/{location_id}/groups` API returns `{"device_groups": None}` so this is a quick fix to remedy the situation!

Fixes #240.