### PR TITLE
fix memory growth when calling url_recording

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -96,8 +96,9 @@ class Ring(object):
         locations.discard(None)
         for location in locations:
             data = self.query(GROUPS_ENDPOINT.format(location)).json()
-            for group in data["device_groups"]:
-                self.groups_data[group["device_group_id"]] = group
+            if data["device_groups"] is not None:
+                for group in data["device_groups"]:
+                    self.groups_data[group["device_group_id"]] = group
 
     def query(
         self, url, method="GET", extra_params=None, data=None, json=None, timeout=None

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -45,6 +45,7 @@ SNAPSHOT_TIMESTAMP_ENDPOINT = "/clients_api/snapshots/timestamps"
 TESTSOUND_CHIME_ENDPOINT = CHIMES_ENDPOINT + "/play_sound"
 URL_DOORBELL_HISTORY = DOORBELLS_ENDPOINT + "/history"
 URL_RECORDING = "/clients_api/dings/{0}/recording"
+URL_RECORDING_SHARE_PLAY = "/clients_api/dings/{0}/share/play"
 GROUP_DEVICES_ENDPOINT = GROUPS_ENDPOINT + "/{1}/devices"
 
 # chime test sound kinds

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -32,6 +32,7 @@ from ring_doorbell.const import (
     SNAPSHOT_TIMESTAMP_ENDPOINT,
     URL_DOORBELL_HISTORY,
     URL_RECORDING,
+    URL_RECORDING_SHARE_PLAY,
     DEFAULT_VIDEO_DOWNLOAD_TIMEOUT,
     HEALTH_DOORBELL_ENDPOINT,
 )
@@ -371,10 +372,11 @@ class RingDoorBell(RingGeneric):
             _LOGGER.warning(msg)
             return False
 
-        url = URL_RECORDING.format(recording_id)
+        url = URL_RECORDING_SHARE_PLAY.format(recording_id)
         req = self._ring.query(url)
-        if req and req.status_code == 200:
-            return req.url
+        data = req.json()
+        if req and req.status_code == 200 and data is not None:
+            return data["url"]
         return False
 
     @property


### PR DESCRIPTION
Eliminates memory growth when calling url_recording.  This also reduces the actual message data transfers by calling a different endpoint, which will only retrieve the URL data rather than the URL + video file

This will address Issue #252 