### PR TITLE
Recognize cocoa_floodlight as a floodlight kind

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -77,7 +77,7 @@ DOORBELL_PRO_KINDS = ["lpd_v1", "lpd_v2", "lpd_v4"]
 DOORBELL_ELITE_KINDS = ["jbox_v1"]
 PEEPHOLE_CAM_KINDS = ["doorbell_portal"]
 
-FLOODLIGHT_CAM_KINDS = ["hp_cam_v1", "floodlight_v2"]
+FLOODLIGHT_CAM_KINDS = ["hp_cam_v1", "floodlight_v2", "cocoa_floodlight"]
 INDOOR_CAM_KINDS = ["stickup_cam_mini"]
 SPOTLIGHT_CAM_BATTERY_KINDS = ["stickup_cam_v4"]
 SPOTLIGHT_CAM_WIRED_KINDS = ["hp_cam_v2", "spotlightw_v2"]


### PR DESCRIPTION
Recognizes device kind for recent generation of Ring Floodlight Cameras, as of June 2021.