### PR TITLE
Fix ci to use up to date python versions and include pre-commit-config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,44 @@
 name: CI
 
 on:
-  - push
+  push:
+  pull_request:
+    branches: ["master"]
 
 jobs:
-  ci:
+  linting:
+    name: "Perform linting checks"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: "Install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U tox
+      - name: Lint with tox
+        run: |
+          tox
+        env: 
+          TOXENV: lint
+
+  tests:
+    name: tests
+    needs: linting
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -26,12 +52,14 @@ jobs:
       - name: Prepare toxenv
         id: toxenv
         run: |
-          if [[ '${{ matrix.python-version }}' == '3.6' ]]; then
-            echo "::set-output name=toxenv::py36"
-          elif [[ '${{ matrix.python-version }}' == '3.7' ]]; then
-            echo "::set-output name=toxenv::py37"
+          if [[ '${{ matrix.python-version }}' == '3.8' ]]; then
+            echo "::set-output name=toxenv::py38"
+          elif [[ '${{ matrix.python-version }}' == '3.9' ]]; then
+            echo "::set-output name=toxenv::py39"
+          elif [[ '${{ matrix.python-version }}' == '3.10' ]]; then
+            echo "::set-output name=toxenv::py310"
           else
-            echo "::set-output name=toxenv::lint"
+            echo "::set-output name=toxenv::py311"
           fi
       - name: Test with tox
         run: |
@@ -42,6 +70,6 @@ jobs:
         run: |
           coveralls --service=github
         # Only report coverage on latest Python version and skip on prior failures
-        if: ${{ success() && matrix.python-version == '3.7' }}
+        if: ${{ success() && matrix.python-version == '3.11' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
+  hooks:
+  - id: flake8
+
+- repo: local
+  hooks:
+  - id: pylint
+    name: pylint
+    entry: pylint
+    language: system
+    types: [python]
+    require_serial: true
+    files: ^ring_doorbell/
+    args:
+      - --rcfile=pylintrc
+
+- repo: https://github.com/python/black
+  rev: 23.3.0
+  hooks:
+  - id: black
+    args:
+      - --check

--- a/pylintrc
+++ b/pylintrc
@@ -6,25 +6,21 @@ reports=no
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
-# abstract-class-little-used - prevents from setting right foundation
-# abstract-class-not-used - is flaky, should not show up but does
 # unused-argument - generic callbacks and setup methods create a lot of warnings
 # global-statement - used for the on-demand requirement installation
 # redefined-variable-type - this is Python, we're duck typing!
 # too-many-* - are not enforced for the sake of readability
 # too-few-* - same as too-many-*
 # abstract-method - with intro of async there are always methods missing
+# consider-using-f-string - not updating legacy string formats at the moment
 
 disable=
   format,
   locally-disabled,
   duplicate-code,
   cyclic-import,
-  abstract-class-little-used,
-  abstract-class-not-used,
   unused-argument,
   global-statement,
-  redefined-variable-type,
   too-many-arguments,
   too-many-branches,
   too-many-instance-attributes,
@@ -34,7 +30,9 @@ disable=
   too-many-statements,
   too-many-lines,
   too-few-public-methods,
-  abstract-method
+  abstract-method,
+  consider-using-f-string,
+  import-error,
 
 [EXCEPTIONS]
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -150,6 +150,7 @@ class RingDoorBell(RingGeneric):
         1: Digital
         2: Not Present
         """
+        # pylint:disable=consider-iterating-dictionary
         if value not in DOORBELL_EXISTING_TYPE.keys():
             _LOGGER.error("%s", MSG_EXISTING_TYPE)
             return False
@@ -177,7 +178,6 @@ class RingDoorBell(RingGeneric):
     def existing_doorbell_type_enabled(self, value):
         """Enable/disable the existing doorbell if Digital/Mechanical."""
         if self.existing_doorbell_type:
-
             if not isinstance(value, bool):
                 _LOGGER.error("%s", MSG_BOOLEAN_REQUIRED)
                 return None
@@ -207,7 +207,6 @@ class RingDoorBell(RingGeneric):
     def existing_doorbell_type_duration(self, value):
         """Set duration for Digital chime."""
         if self.existing_doorbell_type:
-
             if not (
                 (isinstance(value, int))
                 and (DOORBELL_VOL_MIN <= value <= DOORBELL_VOL_MAX)
@@ -251,6 +250,7 @@ class RingDoorBell(RingGeneric):
         original_limit = limit
 
         # set cap for max queries
+        # pylint:disable=consider-using-min-builtin
         if retry > 10:
             retry = 10
 
@@ -349,7 +349,6 @@ class RingDoorBell(RingGeneric):
             # Video download needs a longer timeout to get the large video file
             req = self._ring.query(url, timeout=timeout)
             if req and req.status_code == 200:
-
                 if filename:
                     if os.path.isfile(filename) and not override:
                         _LOGGER.error("%s", FILE_EXISTS.format(filename))

--- a/ring_doorbell/generic.py
+++ b/ring_doorbell/generic.py
@@ -11,6 +11,7 @@ class RingGeneric(object):
     """Generic Implementation for Ring Chime/Doorbell."""
 
     # pylint: disable=redefined-builtin
+    # pylint:disable=invalid-name
     def __init__(self, ring, id):
         """Initialize Ring Generic."""
         self._ring = ring

--- a/ring_doorbell/group.py
+++ b/ring_doorbell/group.py
@@ -11,6 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 class RingLightGroup:
     """Implementation for RingLightGroup."""
 
+    # pylint:disable=invalid-name
     # pylint: disable=redefined-builtin
     def __init__(self, ring, id):
         """Initialize Ring Generic."""
@@ -60,7 +61,6 @@ class RingLightGroup:
         """Return Ring device model name."""
         return "Light Group"
 
-    # pylint:disable=no-self-use
     def has_capability(self, capability):
         """Return if device has specific capability."""
         if capability == "light":

--- a/scripts/ringcli.py
+++ b/scripts/ringcli.py
@@ -44,7 +44,6 @@ def _format_filename(event):
 
 
 def main():
-
     parser = argparse.ArgumentParser(
         description="Ring Doorbell",
         epilog="https://github.com/tchellomello/python-ring-doorbell",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, lint
+envlist = py38, py39, py310, py311, lint
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Trying to get a separate PR together to add motion_detection_enabled switching and encountered issues with the current CI pipeline being broken due to older unsupported python versions 3.6 and 3.7.  This PR updates CI.yaml and tox.ini to bring them up to date.  It also fixes linting issues in the codebase and includes a pre-commit-config.yaml to prevent new linting issues.