### PR TITLE
Add motion detection enabled switch

### DIFF
--- a/ring_doorbell/auth.py
+++ b/ring_doorbell/auth.py
@@ -2,6 +2,7 @@
 # vim:sw=4:ts=4:et:
 """Python Ring Auth Class."""
 from uuid import uuid4 as uuid
+from json import dumps as json_dumps
 from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2 import LegacyApplicationClient, TokenExpiredError
 from ring_doorbell.const import OAuth, API_VERSION, TIMEOUT
@@ -87,6 +88,13 @@ class Auth:
         if method == "POST":
             if json is not None:
                 kwargs["json"] = json
+            if data is not None:
+                kwargs["data"] = data
+
+        if method == "PATCH":
+            # PATCH method of requests library does not have a json argument
+            if json is not None:
+                kwargs["data"] = json_dumps(json)
             if data is not None:
                 kwargs["data"] = data
 

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -47,6 +47,7 @@ URL_DOORBELL_HISTORY = DOORBELLS_ENDPOINT + "/history"
 URL_RECORDING = "/clients_api/dings/{0}/recording"
 URL_RECORDING_SHARE_PLAY = "/clients_api/dings/{0}/share/play"
 GROUP_DEVICES_ENDPOINT = GROUPS_ENDPOINT + "/{1}/devices"
+SETTINGS_ENDPOINT = "/devices/v1/devices/{0}/settings"
 
 # chime test sound kinds
 KIND_DING = "ding"
@@ -94,6 +95,7 @@ MSG_GENERIC_FAIL = "Sorry.. Something went wrong..."
 FILE_EXISTS = "The file {0} already exists."
 MSG_VOL_OUTBOUND = "Must be within the {0}-{1}."
 MSG_ALLOWED_VALUES = "Only the following values are allowed: {0}."
+MSG_EXPECTED_ATTRIBUTE_NOT_FOUND = "Couldn't find expected attribute: {0}."
 
 POST_DATA = {
     "api_version": API_VERSION,

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -92,6 +92,16 @@ class RingStickUpCam(RingDoorBell):
                 + STICKUP_CAM_BATTERY_KINDS
                 + STICKUP_CAM_WIRED_KINDS
             )
+        if capability == "motion_detection":
+            return self.kind in (
+                FLOODLIGHT_CAM_KINDS
+                + FLOODLIGHT_CAM_PRO_KINDS
+                + INDOOR_CAM_KINDS
+                + SPOTLIGHT_CAM_BATTERY_KINDS
+                + SPOTLIGHT_CAM_WIRED_KINDS
+                + STICKUP_CAM_BATTERY_KINDS
+                + STICKUP_CAM_WIRED_KINDS
+            )
         return False
 
     @property

--- a/test.py
+++ b/test.py
@@ -20,11 +20,13 @@ def otp_callback():
 
 def main():
     if cache_file.is_file():
-        auth = Auth("MyProject/1.0", json.loads(cache_file.read_text()), token_updated)
+        auth = Auth(
+            "RingAPI2023/1.0", json.loads(cache_file.read_text()), token_updated
+        )
     else:
         username = input("Username: ")
         password = getpass.getpass("Password: ")
-        auth = Auth("MyProject/1.0", None, token_updated)
+        auth = Auth("RingAPI2023/1.0", None, token_updated)
         try:
             auth.fetch_token(username, password)
         except MissingTokenError:

--- a/tests/fixtures/ring_devices.json
+++ b/tests/fixtures/ring_devices.json
@@ -39,6 +39,7 @@
                     "middle",
                     "high",
                     "highest"],
+                "motion_detection_enabled": true,
                 "motion_announcement": false,
                 "motion_snooze_preset_profile": "low",
                 "motion_snooze_presets": [
@@ -115,6 +116,7 @@
                     "middle",
                     "high",
                     "highest"],
+                "motion_detection_enabled": true,
                 "motion_announcement": false,
                 "motion_snooze_preset_profile": "low",
                 "motion_snooze_presets": [
@@ -179,6 +181,7 @@
                     "middle",
                     "high",
                     "highest"],
+                "motion_detection_enabled": true,
                 "motion_announcement": false,
                 "motion_snooze_preset_profile": "low",
                 "motion_snooze_presets": [

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -72,6 +72,10 @@ def mock_ring_requests():
             "https://api.ring.com/groups/v1/locations/mock-location-id/groups/mock-group-id/devices",
             text="ok",
         )
+        mock.patch(
+            "https://api.ring.com/devices/v1/devices/987652/settings",
+            text="ok",
+        )
         yield mock
 
 
@@ -204,3 +208,18 @@ def test_light_groups(ring):
 
     # Attempt setting lights to invalid value
     group.lights = 30
+
+
+def test_motion_detection_enable(ring, mock_ring_requests):
+    dev = ring.devices()["doorbots"][0]
+
+    dev.motion_detection = True
+    dev.motion_detection = False
+
+    history = list(
+        filter(lambda x: x.method == "PATCH", mock_ring_requests.request_history)
+    )
+    assert history[0].path == "/devices/v1/devices/987652/settings"
+    assert history[0].text == '{"motion_settings": {"motion_detection_enabled": true}}'
+    assert history[1].path == "/devices/v1/devices/987652/settings"
+    assert history[1].text == '{"motion_settings": {"motion_detection_enabled": false}}'


### PR DESCRIPTION
Allows switching off and on of the motion detection.  

The principal use case for this is for indoor cams to turn on automatically when leaving the house or at night but not to be recording when family are around.  N.B. I have an update ready for homeassistant to use this feature.

Feature mentioned in feature request  https://github.com/tchellomello/python-ring-doorbell/issues/126 and solution provided by @jsetton in the same issue.