### PR TITLE
fix typo in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,8 +158,8 @@ Showing door bell events
         events = doorbell.history(kind='motion')
 
 
-Downloading the last video triggered by Ring
---------------------------------------------
+Downloading the last video triggered by a ding or motion event
+--------------------------------------------------------------
 .. code-block:: python
 
     devices = ring.devices()

--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ Showing door bell events
         events = doorbell.history(kind='motion')
 
 
-Downloading the last video triggered by ding
+Downloading the last video triggered by Ring
 --------------------------------------------
 .. code-block:: python
 


### PR DESCRIPTION
There was a typo while I was reading the documentation. I assumed it should have said "Ring" and not "ding"