### PR TITLE
Fix and update cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,11 @@ Python Ring Door Bell
     :alt: Py Versions
     :target: https://pypi.python.org/pypi/ring-doorbell
 
-*Looking for maintainers* 
-
 
 Python Ring Door Bell is a library written for Python 3.8+
 that exposes the Ring.com devices as Python objects.
+
+There is also a command line interface that is work in progress. `Contributors welcome <https://python-ring-doorbell.readthedocs.io/contributing.html>`_.
 
 *Currently Ring.com does not provide an official API. The results of this project are merely from reverse engineering.*
 
@@ -45,6 +45,21 @@ Installation
     $ pip install \
         git+https://github.com/tchellomello/python-ring-doorbell@master
 
+
+Using the CLI
+-------------
+
+The CLI is work in progress and at the moment only displays your device info and video info.
+
+1.  Show your devices::
+    
+    $ ring-doorbell
+
+#.  Either count or download your vidoes or both::
+
+    $ ring-doorbell videos --count --download-all
+
+#.  Run ``ring-doorbell --help`` or ``ring-doorbell videos --help`` for full options
 
 Initializing your Ring object
 -----------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,27 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.0.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "anyio-4.0.0-py3-none-any.whl", hash = "sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f"},
+    {file = "anyio-4.0.0.tar.gz", hash = "sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a"},
+]
+
+[package.dependencies]
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
+idna = ">=2.8"
+sniffio = ">=1.1"
+
+[package.extras]
+doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.17)"]
+trio = ["trio (>=0.22)"]
+
+[[package]]
 name = "astroid"
 version = "2.15.7"
 description = "An abstract syntax tree for Python with inference support."
@@ -29,6 +50,20 @@ wrapt = [
     {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
 ]
+
+[[package]]
+name = "asyncclick"
+version = "8.1.3.4"
+description = "Composable command line interface toolkit, async version"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "asyncclick-8.1.3.4-py3-none-any.whl", hash = "sha256:f8db604e37dabd43922d58f857817b1dfd8f88695b75c4cc1afe7ff1cc238a7b"},
+    {file = "asyncclick-8.1.3.4.tar.gz", hash = "sha256:81d98cbf6c8813f9cd5599f586d56cfc532e9e6441391974d10827abb90fe833"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "babel"
@@ -920,6 +955,17 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.0"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},
+    {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
@@ -1319,4 +1365,4 @@ docs = ["docutils", "sphinx", "sphinx_rtd_theme", "sphinxcontrib-programoutput"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "b663c2d871b1da8a827f09e4c6d3a02fa8199b62d9ab9cfcb4a76def9a2f2751"
+content-hash = "fb62254a286108bbb7d95af8f2ffb5b43a5266d5b78a850172afa24721a8eb7f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ sphinx = { version = "^7", optional = true }
 sphinx_rtd_theme = { version = "^1", optional = true }
 sphinxcontrib-programoutput = { version = "^0", optional = true }
 docutils = { version = ">=0.17", optional = true }
+########################
+
+asyncclick = "^8.1.3.4"
+anyio = "^4.0.0" # see https://github.com/python-trio/asyncclick/issues/18
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "*"

--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -1,146 +1,20 @@
-# coding: utf-8
-# vim:sw=4:ts=4:et:
-"""Python Ring Doorbell wrapper."""
-import logging
-from time import time
+"""Python Package for interacting with Ring devices."""
+from importlib.metadata import version
 
-from .const import (
-    API_URI,
-    DEVICES_ENDPOINT,
-    NEW_SESSION_ENDPOINT,
-    DINGS_ENDPOINT,
-    POST_DATA,
-    GROUPS_ENDPOINT,
-)
-from .auth import Auth  # noqa
-from .doorbot import RingDoorBell
-from .chime import RingChime
-from .stickup_cam import RingStickUpCam
-from .group import RingLightGroup
+__version__ = version("ring_doorbell")
 
+from ring_doorbell.ring import Ring
+from ring_doorbell.auth import Auth
+from ring_doorbell.chime import RingChime
+from ring_doorbell.stickup_cam import RingStickUpCam
+from ring_doorbell.group import RingLightGroup
+from ring_doorbell.doorbot import RingDoorBell
 
-_LOGGER = logging.getLogger(__name__)
-
-
-TYPES = {
-    "stickup_cams": RingStickUpCam,
-    "chimes": RingChime,
-    "doorbots": RingDoorBell,
-    "authorized_doorbots": lambda ring, description: RingDoorBell(
-        ring, description, shared=True
-    ),
-}
-
-
-# pylint: disable=useless-object-inheritance
-class Ring(object):
-    """A Python Abstraction object to Ring Door Bell."""
-
-    def __init__(self, auth):
-        """Initialize the Ring object."""
-        self.auth = auth
-        self.session = None
-        self.devices_data = None
-        self.chime_health_data = None
-        self.doorbell_health_data = None
-        self.dings_data = None
-        self.groups_data = None
-
-    def update_data(self):
-        """Update all data."""
-        if self.session is None:
-            self.create_session()
-
-        self.update_devices()
-
-        self.update_dings()
-
-        self.update_groups()
-
-    def create_session(self):
-        """Create a new Ring session."""
-        session_post_data = POST_DATA
-        session_post_data["device[hardware_id]"] = self.auth.get_hardware_id()
-
-        self.session = self.query(
-            NEW_SESSION_ENDPOINT,
-            method="POST",
-            data=session_post_data,
-        ).json()
-
-    def update_devices(self):
-        """Update device data."""
-        data = self.query(DEVICES_ENDPOINT).json()
-
-        # Index data by device ID.
-        self.devices_data = {
-            device_type: {obj["id"]: obj for obj in devices}
-            for device_type, devices in data.items()
-        }
-
-    def update_dings(self):
-        """Update dings data."""
-        self.dings_data = self.query(DINGS_ENDPOINT).json()
-
-    def update_groups(self):
-        """Update groups data."""
-        # Get all locations
-        locations = set()
-        for devices in self.devices_data.values():
-            for dev in devices.values():
-                if "location_id" in dev:
-                    locations.add(dev["location_id"])
-
-        # Query for groups
-        self.groups_data = {}
-        locations.discard(None)
-        for location in locations:
-            data = self.query(GROUPS_ENDPOINT.format(location)).json()
-            if data["device_groups"] is not None:
-                for group in data["device_groups"]:
-                    self.groups_data[group["device_group_id"]] = group
-
-    def query(
-        self, url, method="GET", extra_params=None, data=None, json=None, timeout=None
-    ):
-        """Query data from Ring API."""
-        return self.auth.query(
-            API_URI + url,
-            method=method,
-            extra_params=extra_params,
-            data=data,
-            json=json,
-            timeout=timeout,
-        )
-
-    def devices(self):
-        """Get all devices."""
-        devices = {}
-
-        for dev_type, convertor in TYPES.items():
-            devices[dev_type] = [
-                convertor(self, obj["id"])
-                for obj in self.devices_data.get(dev_type, {}).values()
-            ]
-
-        return devices
-
-    def groups(self):
-        """Get all groups."""
-        groups = {}
-
-        for group_id in self.groups_data:
-            groups[group_id] = RingLightGroup(self, group_id)
-
-        return groups
-
-    def active_alerts(self):
-        """Get active alerts."""
-        alerts = []
-        for alert in self.dings_data:
-            expires_at = alert.get("now") + alert.get("expires_in")
-
-            if time() < expires_at:
-                alerts.append(alert)
-
-        return alerts
+__all__ = [
+    "Ring",
+    "Auth",
+    "RingChime",
+    "RingStickUpCam",
+    "RingLightGroup",
+    "RingDoorBell",
+]

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -25,6 +25,8 @@ DEFAULT_VIDEO_DOWNLOAD_TIMEOUT = 120
 # API endpoints
 API_VERSION = "9"
 API_URI = "https://api.ring.com"
+USER_AGENT = "RingAPI2023/1.0"
+CLI_TOKEN_FILE = "ring_token.cache"
 CHIMES_ENDPOINT = "/clients_api/chimes/{0}"
 DEVICES_ENDPOINT = "/clients_api/ring_devices"
 DINGS_ENDPOINT = "/clients_api/dings/active"

--- a/ring_doorbell/ring.py
+++ b/ring_doorbell/ring.py
@@ -1,0 +1,143 @@
+# vim:sw=4:ts=4:et:
+"""Python Ring Doorbell module."""
+import logging
+from time import time
+
+from ring_doorbell.doorbot import RingDoorBell
+from ring_doorbell.chime import RingChime
+from ring_doorbell.stickup_cam import RingStickUpCam
+from ring_doorbell.group import RingLightGroup
+from .const import (
+    API_URI,
+    DEVICES_ENDPOINT,
+    NEW_SESSION_ENDPOINT,
+    DINGS_ENDPOINT,
+    POST_DATA,
+    GROUPS_ENDPOINT,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+TYPES = {
+    "stickup_cams": RingStickUpCam,
+    "chimes": RingChime,
+    "doorbots": RingDoorBell,
+    "authorized_doorbots": lambda ring, description: RingDoorBell(
+        ring, description, shared=True
+    ),
+}
+
+
+# pylint: disable=useless-object-inheritance
+class Ring(object):
+    """A Python Abstraction object to Ring Door Bell."""
+
+    def __init__(self, auth):
+        """Initialize the Ring object."""
+        self.auth = auth
+        self.session = None
+        self.devices_data = None
+        self.chime_health_data = None
+        self.doorbell_health_data = None
+        self.dings_data = None
+        self.groups_data = None
+
+    def update_data(self):
+        """Update all data."""
+        if self.session is None:
+            self.create_session()
+
+        self.update_devices()
+
+        self.update_dings()
+
+        self.update_groups()
+
+    def create_session(self):
+        """Create a new Ring session."""
+        session_post_data = POST_DATA
+        session_post_data["device[hardware_id]"] = self.auth.get_hardware_id()
+
+        self.session = self.query(
+            NEW_SESSION_ENDPOINT,
+            method="POST",
+            data=session_post_data,
+        ).json()
+
+    def update_devices(self):
+        """Update device data."""
+        data = self.query(DEVICES_ENDPOINT).json()
+
+        # Index data by device ID.
+        self.devices_data = {
+            device_type: {obj["id"]: obj for obj in devices}
+            for device_type, devices in data.items()
+        }
+
+    def update_dings(self):
+        """Update dings data."""
+        self.dings_data = self.query(DINGS_ENDPOINT).json()
+
+    def update_groups(self):
+        """Update groups data."""
+        # Get all locations
+        locations = set()
+        for devices in self.devices_data.values():
+            for dev in devices.values():
+                if "location_id" in dev:
+                    locations.add(dev["location_id"])
+
+        # Query for groups
+        self.groups_data = {}
+        locations.discard(None)
+        for location in locations:
+            data = self.query(GROUPS_ENDPOINT.format(location)).json()
+            if data["device_groups"] is not None:
+                for group in data["device_groups"]:
+                    self.groups_data[group["device_group_id"]] = group
+
+    def query(
+        self, url, method="GET", extra_params=None, data=None, json=None, timeout=None
+    ):
+        """Query data from Ring API."""
+        return self.auth.query(
+            API_URI + url,
+            method=method,
+            extra_params=extra_params,
+            data=data,
+            json=json,
+            timeout=timeout,
+        )
+
+    def devices(self):
+        """Get all devices."""
+        devices = {}
+
+        for dev_type, convertor in TYPES.items():
+            devices[dev_type] = [
+                convertor(self, obj["id"])
+                for obj in self.devices_data.get(dev_type, {}).values()
+            ]
+
+        return devices
+
+    def groups(self):
+        """Get all groups."""
+        groups = {}
+
+        for group_id in self.groups_data:
+            groups[group_id] = RingLightGroup(self, group_id)
+
+        return groups
+
+    def active_alerts(self):
+        """Get active alerts."""
+        alerts = []
+        for alert in self.dings_data:
+            expires_at = alert.get("now") + alert.get("expires_in")
+
+            if time() < expires_at:
+                alerts.append(alert)
+
+        return alerts

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -3,7 +3,7 @@
 """Python Ring Doorbell wrapper."""
 import logging
 
-from ring_doorbell import RingDoorBell
+from ring_doorbell.doorbot import RingDoorBell
 from ring_doorbell.const import (
     LIGHTS_ENDPOINT,
     MSG_ALLOWED_VALUES,

--- a/scripts/ringcli.py
+++ b/scripts/ringcli.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# vim:sw=4:ts=4:et
+# Many thanks to @troopermax <https://github.com/troopermax>
+"""DEPRACATED script which just runs the cli videos subcommand.
+
+Deprecated as you can either call the cli directly:
+
+ring_doorbell/cli.py videos
+
+Or use the ring-doorbell script if you installed ring_doorbell via poetry or pip
+
+ring-doorbell videos
+"""
+import sys
+from ring_doorbell.cli import cli
+
+if __name__ == "__main__":
+    sys.argv.insert(1, "videos")
+    sys.exit(cli())

--- a/test.py
+++ b/test.py
@@ -1,51 +1,9 @@
-import json
-import getpass
-from pathlib import Path
-
-from ring_doorbell import Ring, Auth
-from oauthlib.oauth2 import MissingTokenError
-
-
-cache_file = Path("test_token.cache")
-
-
-def token_updated(token):
-    cache_file.write_text(json.dumps(token))
-
-
-def otp_callback():
-    auth_code = input("2FA code: ")
-    return auth_code
-
-
-def main():
-    if cache_file.is_file():
-        auth = Auth(
-            "RingAPI2023/1.0", json.loads(cache_file.read_text()), token_updated
-        )
-    else:
-        username = input("Username: ")
-        password = getpass.getpass("Password: ")
-        auth = Auth("RingAPI2023/1.0", None, token_updated)
-        try:
-            auth.fetch_token(username, password)
-        except MissingTokenError:
-            auth.fetch_token(username, password, otp_callback())
-
-    ring = Ring(auth)
-    ring.update_data()
-
-    devices = ring.devices()
-    print(devices)
-
-    doorbells = devices["doorbots"]
-    chimes = devices["chimes"]
-    stickup_cams = devices["stickup_cams"]
-
-    print(doorbells)
-    print(chimes)
-    print(stickup_cams)
-
+"""Test module which just runs the cli.  Deprecated as you can either call the cli directly:
+python3 ring_doorbell/cli.py
+Or use the ring-doorbell script if you installed ring_doorbell via poetry or pip
+"""
+import sys
+from ring_doorbell.cli import cli
 
 if __name__ == "__main__":
-    main()
+    sys.exit(cli())


### PR DESCRIPTION
This PR fixes some issues with the cli and updates the documentation:

- If the existing token_cash is invalid then reauthorise
- Update the previous ringclip.py to call ring_doorbell/cli with `videos` option and mark as deprecated
- Update test.py to call ring_doorbell/cli and mark as deprecated
- Update cli to use asyncclick
- Update README to contain cli instructions
- Move Ring class out of `__init__.py` into its own module
- Tests still to be added