### PR TITLE
Add custom exceptions and encapsulate oauth error handling

### DIFF
--- a/ring_doorbell/__init__.py
+++ b/ring_doorbell/__init__.py
@@ -6,6 +6,12 @@ __version__ = version("ring_doorbell")
 from ring_doorbell.auth import Auth
 from ring_doorbell.chime import RingChime
 from ring_doorbell.doorbot import RingDoorBell
+from ring_doorbell.exceptions import (
+    AuthenticationError,
+    Requires2FAError,
+    RingError,
+    RingTimeout,
+)
 from ring_doorbell.generic import RingEvent
 from ring_doorbell.group import RingLightGroup
 from ring_doorbell.ring import Ring
@@ -19,4 +25,8 @@ __all__ = [
     "RingLightGroup",
     "RingDoorBell",
     "RingEvent",
+    "RingError",
+    "AuthenticationError",
+    "Requires2FAError",
+    "RingTimeout",
 ]

--- a/ring_doorbell/exceptions.py
+++ b/ring_doorbell/exceptions.py
@@ -1,0 +1,17 @@
+"""ring-doorbell exceptions."""
+
+
+class RingError(Exception):
+    """Base exception for device errors."""
+
+
+class Requires2FAError(RingError):
+    """Exception that 2FA is required."""
+
+
+class AuthenticationError(RingError):
+    """Exception for ring authentication errors."""
+
+
+class RingTimeout(RingError):
+    """Exception for ring authentication errors."""

--- a/ring_doorbell/listen.py
+++ b/ring_doorbell/listen.py
@@ -149,10 +149,11 @@ class RingEventListener:
         gcm_data_json = json.loads(notification["data"]["gcmData"])
 
         if "ding" not in gcm_data_json:
-            _logger.error(
-                "Cannot find ding in gcmData.  Full message is:\n%s",
-                json.dumps(notification),
-            )
+            if "community_alert" not in gcm_data_json:
+                _logger.warning(
+                    "Unexpected alert type in gcmData.  Full message is:\n%s",
+                    json.dumps(notification),
+                )
             return
 
         ding = gcm_data_json["ding"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,9 +6,8 @@ from unittest.mock import DEFAULT, MagicMock
 
 import pytest
 from asyncclick.testing import CliRunner
-from oauthlib.oauth2 import InvalidGrantError, MissingTokenError
 
-from ring_doorbell import Ring
+from ring_doorbell import AuthenticationError, Requires2FAError, Ring
 from ring_doorbell.cli import (
     cli,
     devices_command,
@@ -100,8 +99,8 @@ async def test_videos(ring, mocker):
     "affect_method, exception, file_exists",
     [
         (None, None, False),
-        ("ring_doorbell.auth.Auth.fetch_token", MissingTokenError, False),
-        ("ring_doorbell.ring.Ring.update_data", InvalidGrantError, True),
+        ("ring_doorbell.auth.Auth.fetch_token", Requires2FAError, False),
+        ("ring_doorbell.ring.Ring.update_data", AuthenticationError, True),
     ],
     ids=("No 2FA", "Require 2FA", "Invalid Grant"),
 )


### PR DESCRIPTION
Add custom exceptions to encapsulate oauth/token related errors away from consumers and handle situations where tokens are invalidated on the ring website and queries return 401 errors.  As this is a breaking change for consumers currently handling oauthlib.oauth2 errors directly it will go into a new minor release.