### PR TITLE
Add ring devices and bump version to 0.8.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ring-doorbell"
-version = "0.8.1"
+version = "0.8.2"
 description = "A Python library to communicate with Ring Door Bell (https://ring.com/)"
 authors = ["Marcelo Moreira de Mello <tchello.mello@gmail.com>"]
 license = "LGPLv3+"

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -82,22 +82,31 @@ SIREN_DURATION_MAX = 120
 CHIME_KINDS = ["chime", "chime_v2"]
 CHIME_PRO_KINDS = ["chime_pro", "chime_pro_v2"]
 
-DOORBELL_KINDS = ["doorbot", "doorbell", "doorbell_v3", "cocoa_doorbell"]
+DOORBELL_KINDS = ["doorbot", "doorbell", "doorbell_v3"]
 DOORBELL_2_KINDS = ["doorbell_v4", "doorbell_v5"]
 DOORBELL_3_KINDS = ["doorbell_scallop_lite"]
+DOORBELL_4_KINDS = ["doorbell_oyster"]  # Added
 DOORBELL_3_PLUS_KINDS = ["doorbell_scallop"]
-DOORBELL_PRO_KINDS = ["lpd_v1", "lpd_v2", "lpd_v4"]
+DOORBELL_PRO_KINDS = ["lpd_v1", "lpd_v2", "lpd_v3"]
+DOORBELL_PRO_2_KINDS = ["lpd_v4"]
 DOORBELL_ELITE_KINDS = ["jbox_v1"]
+DOORBELL_WIRED_KINDS = ["doorbell_graham_cracker"]
 PEEPHOLE_CAM_KINDS = ["doorbell_portal"]
+DOORBELL_GEN2_KINDS = ["cocoa_doorbell", "cocoa_doorbell_v2"]
 
-FLOODLIGHT_CAM_KINDS = ["hp_cam_v1", "floodlight_v2", "cocoa_floodlight"]
+FLOODLIGHT_CAM_KINDS = ["hp_cam_v1", "floodlight_v2"]
 FLOODLIGHT_CAM_PRO_KINDS = ["floodlight_pro"]
+FLOODLIGHT_CAM_PLUS_KINDS = ["cocoa_floodlight"]
 INDOOR_CAM_KINDS = ["stickup_cam_mini"]
+INDOOR_CAM_GEN2_KINDS = ["stickup_cam_mini_v2"]
 SPOTLIGHT_CAM_BATTERY_KINDS = ["stickup_cam_v4"]
 SPOTLIGHT_CAM_WIRED_KINDS = ["hp_cam_v2", "spotlightw_v2"]
+SPOTLIGHT_CAM_PLUS_KINDS = ["cocoa_spotlight"]
 STICKUP_CAM_KINDS = ["stickup_cam", "stickup_cam_v3"]
-STICKUP_CAM_BATTERY_KINDS = ["cocoa_camera", "stickup_cam_lunar"]
-STICKUP_CAM_WIRED_KINDS = ["stickup_cam_elite"]
+STICKUP_CAM_BATTERY_KINDS = ["stickup_cam_lunar"]
+STICKUP_CAM_ELITE_KINDS = ["stickup_cam_elite", "stickup_cam_wired"]
+STICKUP_CAM_WIRED_KINDS = STICKUP_CAM_ELITE_KINDS  # Deprecated
+STICKUP_CAM_GEN3_KINDS = ["cocoa_camera"]
 BEAM_KINDS = ["beams_ct200_transformer"]
 
 # error strings

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -14,12 +14,16 @@ from ring_doorbell.const import (
     DOORBELL_2_KINDS,
     DOORBELL_3_KINDS,
     DOORBELL_3_PLUS_KINDS,
+    DOORBELL_4_KINDS,
     DOORBELL_ELITE_KINDS,
     DOORBELL_EXISTING_TYPE,
+    DOORBELL_GEN2_KINDS,
     DOORBELL_KINDS,
+    DOORBELL_PRO_2_KINDS,
     DOORBELL_PRO_KINDS,
     DOORBELL_VOL_MAX,
     DOORBELL_VOL_MIN,
+    DOORBELL_WIRED_KINDS,
     DOORBELLS_ENDPOINT,
     FILE_EXISTS,
     HEALTH_DOORBELL_ENDPOINT,
@@ -74,10 +78,18 @@ class RingDoorBell(RingGeneric):
             return "Doorbell 3"
         if self.kind in DOORBELL_3_PLUS_KINDS:
             return "Doorbell 3 Plus"
+        if self.kind in DOORBELL_4_KINDS:
+            return "Doorbell 4"
         if self.kind in DOORBELL_PRO_KINDS:
             return "Doorbell Pro"
+        if self.kind in DOORBELL_PRO_2_KINDS:
+            return "Doorbell Pro 2"
         if self.kind in DOORBELL_ELITE_KINDS:
             return "Doorbell Elite"
+        if self.kind in DOORBELL_WIRED_KINDS:
+            return "Doorbell Wired"
+        if self.kind in DOORBELL_GEN2_KINDS:
+            return "Doorbell (2nd Gen)"
         if self.kind in PEEPHOLE_CAM_KINDS:
             return "Peephole Cam"
         return None
@@ -90,6 +102,8 @@ class RingDoorBell(RingGeneric):
                 + DOORBELL_2_KINDS
                 + DOORBELL_3_KINDS
                 + DOORBELL_3_PLUS_KINDS
+                + DOORBELL_4_KINDS
+                + DOORBELL_GEN2_KINDS
                 + PEEPHOLE_CAM_KINDS
             )
         if capability == "knock":
@@ -104,6 +118,11 @@ class RingDoorBell(RingGeneric):
                 + DOORBELL_2_KINDS
                 + DOORBELL_3_KINDS
                 + DOORBELL_3_PLUS_KINDS
+                + DOORBELL_4_KINDS
+                + DOORBELL_PRO_KINDS
+                + DOORBELL_PRO_2_KINDS
+                + DOORBELL_WIRED_KINDS
+                + DOORBELL_GEN2_KINDS
                 + PEEPHOLE_CAM_KINDS
             )
         return False

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -5,8 +5,10 @@ import logging
 
 from ring_doorbell.const import (
     FLOODLIGHT_CAM_KINDS,
+    FLOODLIGHT_CAM_PLUS_KINDS,
     FLOODLIGHT_CAM_PRO_KINDS,
     HEALTH_DOORBELL_ENDPOINT,
+    INDOOR_CAM_GEN2_KINDS,
     INDOOR_CAM_KINDS,
     LIGHTS_ENDPOINT,
     MSG_ALLOWED_VALUES,
@@ -15,10 +17,12 @@ from ring_doorbell.const import (
     SIREN_DURATION_MIN,
     SIREN_ENDPOINT,
     SPOTLIGHT_CAM_BATTERY_KINDS,
+    SPOTLIGHT_CAM_PLUS_KINDS,
     SPOTLIGHT_CAM_WIRED_KINDS,
     STICKUP_CAM_BATTERY_KINDS,
+    STICKUP_CAM_ELITE_KINDS,
+    STICKUP_CAM_GEN3_KINDS,
     STICKUP_CAM_KINDS,
-    STICKUP_CAM_WIRED_KINDS,
 )
 from ring_doorbell.doorbot import RingDoorBell
 
@@ -48,8 +52,12 @@ class RingStickUpCam(RingDoorBell):
             return "Floodlight Cam"
         if self.kind in FLOODLIGHT_CAM_PRO_KINDS:
             return "Floodlight Cam Pro"
+        if self.kind in FLOODLIGHT_CAM_PLUS_KINDS:
+            return "Floodlight Cam Plus"
         if self.kind in INDOOR_CAM_KINDS:
             return "Indoor Cam"
+        if self.kind in INDOOR_CAM_GEN2_KINDS:
+            return "Indoor Cam (2nd Gen)"
         if self.kind in SPOTLIGHT_CAM_BATTERY_KINDS:
             return "Spotlight Cam {}".format(
                 self._attrs.get("ring_cam_setup_flow", "battery").title()
@@ -58,12 +66,16 @@ class RingStickUpCam(RingDoorBell):
             return "Spotlight Cam {}".format(
                 self._attrs.get("ring_cam_setup_flow", "wired").title()
             )
+        if self.kind in SPOTLIGHT_CAM_PLUS_KINDS:
+            return "Spotlight Cam Plus"
         if self.kind in STICKUP_CAM_KINDS:
             return "Stick Up Cam"
         if self.kind in STICKUP_CAM_BATTERY_KINDS:
             return "Stick Up Cam Battery"
-        if self.kind in STICKUP_CAM_WIRED_KINDS:
+        if self.kind in STICKUP_CAM_ELITE_KINDS:
             return "Stick Up Cam Wired"
+        if self.kind in STICKUP_CAM_GEN3_KINDS:
+            return "Stick Up Cam (3rd Gen)"
         _LOGGER.error("Unknown kind: %s", self.kind)
         return None
 
@@ -74,33 +86,44 @@ class RingStickUpCam(RingDoorBell):
                 SPOTLIGHT_CAM_BATTERY_KINDS
                 + STICKUP_CAM_KINDS
                 + STICKUP_CAM_BATTERY_KINDS
+                + STICKUP_CAM_GEN3_KINDS
             )
         if capability == "light":
             return self.kind in (
                 FLOODLIGHT_CAM_KINDS
                 + FLOODLIGHT_CAM_PRO_KINDS
+                + FLOODLIGHT_CAM_PLUS_KINDS
                 + SPOTLIGHT_CAM_BATTERY_KINDS
                 + SPOTLIGHT_CAM_WIRED_KINDS
+                + SPOTLIGHT_CAM_PLUS_KINDS
             )
         if capability == "siren":
             return self.kind in (
                 FLOODLIGHT_CAM_KINDS
                 + FLOODLIGHT_CAM_PRO_KINDS
+                + FLOODLIGHT_CAM_PLUS_KINDS
                 + INDOOR_CAM_KINDS
+                + INDOOR_CAM_GEN2_KINDS
                 + SPOTLIGHT_CAM_BATTERY_KINDS
                 + SPOTLIGHT_CAM_WIRED_KINDS
+                + SPOTLIGHT_CAM_PLUS_KINDS
                 + STICKUP_CAM_BATTERY_KINDS
-                + STICKUP_CAM_WIRED_KINDS
+                + STICKUP_CAM_ELITE_KINDS
+                + STICKUP_CAM_GEN3_KINDS
             )
         if capability in ("motion_detection", "video"):
             return self.kind in (
                 FLOODLIGHT_CAM_KINDS
                 + FLOODLIGHT_CAM_PRO_KINDS
+                + FLOODLIGHT_CAM_PLUS_KINDS
                 + INDOOR_CAM_KINDS
+                + INDOOR_CAM_GEN2_KINDS
                 + SPOTLIGHT_CAM_BATTERY_KINDS
                 + SPOTLIGHT_CAM_WIRED_KINDS
+                + SPOTLIGHT_CAM_PLUS_KINDS
                 + STICKUP_CAM_BATTERY_KINDS
-                + STICKUP_CAM_WIRED_KINDS
+                + STICKUP_CAM_ELITE_KINDS
+                + STICKUP_CAM_GEN3_KINDS
             )
         return False
 


### PR DESCRIPTION
Add the following missing devices and updates some of the incorrect device naming:

stickup_cam_wired - new elite
stickup_cam_mini_v2 - new indoor
lpd_v3 - missing doorbell pro
doorbell_graham_cracker- missing doorbell wired
cocoa_doorbell_v2 - new 2nd Gen
doorbell_oyster - missing doorbell 4
cocoa_spotlight - new spotlight plus