### PR TITLE
Handle Intercom unlock event

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -67,9 +67,10 @@ INTERCOM_INVITATIONS_ENDPOINT = LOCATIONS_ENDPOINT + "/invitations"
 INTERCOM_INVITATIONS_DELETE_ENDPOINT = LOCATIONS_ENDPOINT + "/invitations/{1}"
 INTERCOM_ALLOWED_USERS = LOCATIONS_ENDPOINT + "/users"
 
-# chime test sound kinds
 KIND_DING = "ding"
 KIND_MOTION = "motion"
+KIND_INTERCOM_UNLOCK = "intercom_unlock"
+# chime test sound kinds
 CHIME_TEST_SOUND_KINDS = (KIND_DING, KIND_MOTION)
 
 # default values
@@ -138,6 +139,7 @@ MSG_EXPECTED_ATTRIBUTE_NOT_FOUND = "Couldn't find expected attribute: {0}."
 
 PUSH_ACTION_DING = "com.ring.push.HANDLE_NEW_DING"
 PUSH_ACTION_MOTION = "com.ring.push.HANDLE_NEW_motion"
+PUSH_ACTION_INTERCOM_UNLOCK = "com.ring.push.INTERCOM_UNLOCK_FROM_APP"
 
 POST_DATA_JSON = {
     "api_version": API_VERSION,

--- a/ring_doorbell/ring.py
+++ b/ring_doorbell/ring.py
@@ -197,6 +197,19 @@ class Ring:
         )
         return device
 
+    def get_device_by_api_id(self, device_api_id):
+        """Return a device using it's id."""
+        all_devices = self.get_device_list()
+        api_id_to_idx = {
+            device.device_api_id: idx for (idx, device) in enumerate(all_devices)
+        }
+        device = (
+            None
+            if device_api_id not in api_id_to_idx
+            else all_devices[api_id_to_idx[device_api_id]]
+        )
+        return device
+
     def video_devices(self):
         """Get all devices."""
         devices = self.devices()

--- a/tests/fixtures/ring_listen_intercom_unlock.json
+++ b/tests/fixtures/ring_listen_intercom_unlock.json
@@ -1,0 +1,10 @@
+{
+    "aps": {
+        "alert": "Your Ingresso in Casetta was used to unlock the entrance on 2\\/2\\/24 at 12:10 PM"
+    },
+    "action": "com.ring.push.INTERCOM_UNLOCK_FROM_APP",
+    "alarm_meta": {
+        "device_zid": 185036587,
+        "location_id": "1234abcd-12cd-123f-de12-0123456789ab"
+    }
+}

--- a/tests/test_listen.py
+++ b/tests/test_listen.py
@@ -53,7 +53,6 @@ async def test_active_dings(auth, mocker):
     ring = Ring(auth)
     listener = RingEventListener(ring)
     listener.start()
-    ring.update_dings()
     assert firebase_messaging.FcmPushClient.checkin.call_count == 1
     assert firebase_messaging.FcmPushClient.start.call_count == 1
     assert listener.subscribed is True
@@ -85,6 +84,31 @@ async def test_active_dings(auth, mocker):
 
     dings = ring.active_alerts()
     assert len(dings) == num_active + alertstoadd
+    listener.stop()
+
+
+async def test_intercom_unlock(auth, mocker):
+    import firebase_messaging
+
+    ring = Ring(auth)
+    listener = RingEventListener(ring)
+    listener.start()
+    assert firebase_messaging.FcmPushClient.checkin.call_count == 1
+    assert firebase_messaging.FcmPushClient.start.call_count == 1
+    assert listener.subscribed is True
+    assert listener.started is True
+    num_active = len(ring.active_alerts())
+    assert num_active == 3
+    alertstoadd = 2
+    for i in range(alertstoadd):
+        msg = json.loads(load_fixture("ring_listen_fcmdata.json"))
+        gcmdata_dict = json.loads(load_fixture("ring_listen_intercom_unlock.json"))
+        msg["data"]["gcmData"] = json.dumps(gcmdata_dict)
+        listener.on_notification(msg, "1234567" + str(i))
+
+    dings = ring.active_alerts()
+    assert len(dings) == num_active + alertstoadd
+
     listener.stop()
 
 


### PR DESCRIPTION
Handle the ring intercom door unlock event and `log.debug` on unknown events instead of warning