### PR TITLE
Update release workflow action to use poetry 1.8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: ["master"]
 
 env:
-  POETRY_VERSION: 1.8.2
+  POETRY_VERSION: 1.8.3
 
 jobs:
   linting:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath
-          pipx install poetry==1.6.1
+          pipx install poetry==1.8.3
       - name: Build and publish
         run: |
           poetry build

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -142,11 +142,13 @@ git rebase upstream/master
 Note, add changelog release notes as the tag commit message so `gh release create --notes-from-tag` can be used to create a release draft.
 
 ```bash
-git tag --annotate $NEW_RELEASE -m "$RELEASE_NOTES"
+git tag --annotate $NEW_RELEASE -m "$RELEASE_NOTES"  # to create a signed tag replace --annotate with --sign
 git push upstream $NEW_RELEASE
 ```
 
 ### Create release
+
+N.B. the `--notes-from-tag` option requires gh cli version >= 2.35.0
 
 #### Pre-releases
 


### PR DESCRIPTION
The previous poetry version 1.6.1 did not correctly populate the PKG-INFO to include python 3.12