### PR TITLE
Support new device Ring Intercom Video

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -186,7 +186,7 @@ STICKUP_CAM_WIRED_KINDS = STICKUP_CAM_ELITE_KINDS  # Deprecated
 STICKUP_CAM_GEN3_KINDS = ["cocoa_camera"]
 BEAM_KINDS = ["beams_ct200_transformer"]
 
-INTERCOM_KINDS = ["intercom_handset_audio"]
+INTERCOM_KINDS = ["intercom_handset_audio", "intercom_handset_video"]
 
 # error strings
 MSG_BOOLEAN_REQUIRED = "Boolean value is required."


### PR DESCRIPTION
This PR adds support for the Ring Intercom Video by simply extending the `INTERCOM_KINDS` constant with `intercom_handset_video`. I performed manual tests by querying the API and the device can be identified after this change.

https://ring.com/de/de/products/intercom-video