### PR TITLE
Add support for Battery Doorbell Pro and Outdoor Cam Plus

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -169,6 +169,7 @@ DOORBELL_WIRED_KINDS = ["doorbell_graham_cracker"]
 DOORBELL_BATTERY_KINDS = ["df_doorbell_clownfish"]
 PEEPHOLE_CAM_KINDS = ["doorbell_portal"]
 DOORBELL_GEN2_KINDS = ["cocoa_doorbell", "cocoa_doorbell_v2"]
+BATTERY_DOORBELL_PRO_KINDS = ["cocoa_doorbell_v5"]
 
 FLOODLIGHT_CAM_KINDS = ["hp_cam_v1", "floodlight_v2"]
 FLOODLIGHT_CAM_PRO_KINDS = ["floodlight_pro"]
@@ -185,6 +186,7 @@ STICKUP_CAM_BATTERY_KINDS = ["stickup_cam_lunar"]
 STICKUP_CAM_ELITE_KINDS = ["stickup_cam_elite", "stickup_cam_wired"]
 STICKUP_CAM_WIRED_KINDS = STICKUP_CAM_ELITE_KINDS  # Deprecated
 STICKUP_CAM_GEN3_KINDS = ["cocoa_camera"]
+OUTDOOR_CAM_PLUS_KINDS = ["cocoa_camera_v2"]
 BEAM_KINDS = ["beams_ct200_transformer"]
 
 INTERCOM_KINDS = ["intercom_handset_audio", "intercom_handset_video"]

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import aiofiles
 
 from ring_doorbell.const import (
+    BATTERY_DOORBELL_PRO_KINDS,
     DEFAULT_VIDEO_DOWNLOAD_TIMEOUT,
     DINGS_ENDPOINT,
     DOORBELL_2_KINDS,
@@ -106,6 +107,8 @@ class RingDoorBell(RingGeneric):
             return "Doorbell (2nd Gen)"
         if self.kind in PEEPHOLE_CAM_KINDS:
             return "Peephole Cam"
+        if self.kind in BATTERY_DOORBELL_PRO_KINDS:
+            return "Battery Doorbell Pro"
         return "Unknown Doorbell"
 
     def has_capability(self, capability: RingCapability | str) -> bool:  # noqa: PLR0911
@@ -124,6 +127,7 @@ class RingDoorBell(RingGeneric):
                 + DOORBELL_4_KINDS
                 + DOORBELL_GEN2_KINDS
                 + DOORBELL_BATTERY_KINDS
+                + BATTERY_DOORBELL_PRO_KINDS
                 + PEEPHOLE_CAM_KINDS
             )
         if capability == RingCapability.KNOCK:
@@ -149,6 +153,7 @@ class RingDoorBell(RingGeneric):
                 + DOORBELL_PRO_2_KINDS
                 + DOORBELL_WIRED_KINDS
                 + DOORBELL_BATTERY_KINDS
+                + BATTERY_DOORBELL_PRO_KINDS
                 + DOORBELL_GEN2_KINDS
                 + DOORBELL_ELITE_KINDS
                 + PEEPHOLE_CAM_KINDS

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -16,6 +16,7 @@ from ring_doorbell.const import (
     LIGHTS_ENDPOINT,
     MSG_ALLOWED_VALUES,
     MSG_VOL_OUTBOUND,
+    OUTDOOR_CAM_PLUS_KINDS,
     SIREN_DURATION_MAX,
     SIREN_DURATION_MIN,
     SIREN_ENDPOINT,
@@ -78,6 +79,8 @@ class RingStickUpCam(RingDoorBell):
             return "Stick Up Cam Wired"
         if self.kind in STICKUP_CAM_GEN3_KINDS:
             return "Stick Up Cam (3rd Gen)"
+        if self.kind in OUTDOOR_CAM_PLUS_KINDS:
+            return "Outdoor Cam Plus"
         _LOGGER.error("Unknown kind: %s", self.kind)
         return "Unknown Stickup Cam"
 
@@ -96,6 +99,7 @@ class RingStickUpCam(RingDoorBell):
                 + STICKUP_CAM_KINDS
                 + STICKUP_CAM_BATTERY_KINDS
                 + STICKUP_CAM_GEN3_KINDS
+                + OUTDOOR_CAM_PLUS_KINDS
             )
         if capability == RingCapability.LIGHT:
             return self.kind in (
@@ -122,6 +126,7 @@ class RingStickUpCam(RingDoorBell):
                 + STICKUP_CAM_BATTERY_KINDS
                 + STICKUP_CAM_ELITE_KINDS
                 + STICKUP_CAM_GEN3_KINDS
+                + OUTDOOR_CAM_PLUS_KINDS
             )
         if capability in [RingCapability.MOTION_DETECTION, RingCapability.VIDEO]:
             return self.kind in (
@@ -139,6 +144,7 @@ class RingStickUpCam(RingDoorBell):
                 + STICKUP_CAM_BATTERY_KINDS
                 + STICKUP_CAM_ELITE_KINDS
                 + STICKUP_CAM_GEN3_KINDS
+                + OUTDOOR_CAM_PLUS_KINDS
             )
         return False
 


### PR DESCRIPTION
- Add cocoa_doorbell_v5 (Battery Doorbell Pro) with battery, motion, video, ding capabilities
- Add cocoa_camera_v2 (Outdoor Cam Plus) with battery, motion, video, siren capabilities
- Add BATTERY_DOORBELL_PRO_KINDS and OUTDOOR_CAM_PLUS_KINDS constants
    - Battery Doorbell Pro: battery, motion detection, video, ding
    - Outdoor Cam Plus: battery, motion detection, video, siren