### PR TITLE
Add Ring Pan-Tilt Indoor Cam to Ring Integration

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -185,6 +185,7 @@ STICKUP_CAM_BATTERY_KINDS = ["stickup_cam_lunar"]
 STICKUP_CAM_ELITE_KINDS = ["stickup_cam_elite", "stickup_cam_wired"]
 STICKUP_CAM_WIRED_KINDS = STICKUP_CAM_ELITE_KINDS  # Deprecated
 STICKUP_CAM_GEN3_KINDS = ["cocoa_camera"]
+STICKUP_CAM_MINI_PTZ_KINDS = ["stickup_cam_mini_ptz_v1"]
 BEAM_KINDS = ["beams_ct200_transformer"]
 
 INTERCOM_KINDS = ["intercom_handset_audio", "intercom_handset_video"]

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -16,6 +16,7 @@ from ring_doorbell.const import (
     LIGHTS_ENDPOINT,
     MSG_ALLOWED_VALUES,
     MSG_VOL_OUTBOUND,
+    STICKUP_CAM_MINI_PTZ_KINDS,
     SIREN_DURATION_MAX,
     SIREN_DURATION_MIN,
     SIREN_ENDPOINT,
@@ -78,6 +79,8 @@ class RingStickUpCam(RingDoorBell):
             return "Stick Up Cam Wired"
         if self.kind in STICKUP_CAM_GEN3_KINDS:
             return "Stick Up Cam (3rd Gen)"
+        if self.kind in STICKUP_CAM_MINI_PTZ_KINDS:  
+            return "Pan-Tilt Indoor Cam"
         _LOGGER.error("Unknown kind: %s", self.kind)
         return "Unknown Stickup Cam"
 
@@ -96,6 +99,7 @@ class RingStickUpCam(RingDoorBell):
                 + STICKUP_CAM_KINDS
                 + STICKUP_CAM_BATTERY_KINDS
                 + STICKUP_CAM_GEN3_KINDS
+                + STICKUP_CAM_MINI_PTZ_KINDS
             )
         if capability == RingCapability.LIGHT:
             return self.kind in (
@@ -122,6 +126,7 @@ class RingStickUpCam(RingDoorBell):
                 + STICKUP_CAM_BATTERY_KINDS
                 + STICKUP_CAM_ELITE_KINDS
                 + STICKUP_CAM_GEN3_KINDS
+                + STICKUP_CAM_MINI_PTZ_KINDS
             )
         if capability in [RingCapability.MOTION_DETECTION, RingCapability.VIDEO]:
             return self.kind in (
@@ -139,6 +144,7 @@ class RingStickUpCam(RingDoorBell):
                 + STICKUP_CAM_BATTERY_KINDS
                 + STICKUP_CAM_ELITE_KINDS
                 + STICKUP_CAM_GEN3_KINDS
+                + STICKUP_CAM_MINI_PTZ_KINDS
             )
         return False
 


### PR DESCRIPTION
The changes allow the Ring Integration to recognize the Pan-Tilt Indoor Cam (stickup_cam_mini_ptz_v1), instead of reporting it as an Unknown Stickup Cam.

After manually making these changes in my Home Assistant implementation, it recognizes the camera as a "Pan-Tilt Indoor Cam" now and reports 10 entities:

Battery
Last Activity
Last Recording
Live View
Motion
Motion Detection
Siren
Volume

This Pull Request should fix [https://github.com/python-ring-doorbell/python-ring-doorbell/issues/495](https://github.com/python-ring-doorbell/python-ring-doorbell/issues/495)