### PR TITLE
Update github action versions to latest and fix release workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,13 +18,13 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v6
       with:
         enable-cache: true
         version: "${{ inputs.uv-version }}"
 
     - name: "Setup python"
-      uses: "actions/setup-python@v5"
+      uses: "actions/setup-python@v6"
       id: setup-python
       with:
         python-version: "${{ inputs.python-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.12"]
     steps:
       - name: "Checkout source files"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
       - name: Setup environment
         uses: ./.github/actions/setup
         with:
@@ -39,7 +39,7 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v6"
       - name: Setup environment
         uses: ./.github/actions/setup
         with:
@@ -67,7 +67,7 @@ jobs:
             python-version: "pypy-3.10"
 
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v6"
       - name: Setup environment
         uses: ./.github/actions/setup
         with:
@@ -79,7 +79,7 @@ jobs:
           --cov=${{ env.PACKAGE_NAME }} --cov-report=xml
           --cov-report=term-missing --import-mode importlib
       - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v2.2.3
+        uses: coverallsapp/github-action@v2.3.6
         with:
           file: coverage.xml
           debug: true
@@ -92,6 +92,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close parallel build
-        uses: coverallsapp/github-action@v2.2.3
+        uses: coverallsapp/github-action@v2.3.6
         with:
           parallel-finished: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
     - name: Checkout source files
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v6
       with:
         version: ${{ env.UV_VERSION }}
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
@@ -36,7 +36,7 @@ jobs:
       run: uv build
 
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: python-package-distributions
         path: dist/
@@ -56,7 +56,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: python-package-distributions
         path: dist/
@@ -76,12 +76,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3
       with:
         inputs: >-
           ./dist/*.tar.gz
@@ -121,7 +121,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+# This workflow creates a GitHub Release via workflow dispatch in case the job publish fails.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to release (for example: v1.2.3)"
+        required: true
+        type: string
+      publish_run_id:
+        description: "Run ID of the publish workflow that produced python-package-distributions"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+
+jobs:
+  github-release:
+    name: Create github release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v6
+      with:
+        name: python-package-distributions
+        path: dist/
+        run-id: ${{ inputs.publish_run_id }}
+        github-token: ${{ github.token }}
+
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Repo clone is required for --notes-from-tag to work
+      run: |
+        gh repo clone '${{ github.repository }}'
+        cd ${{ github.event.repository.name }}
+        gh release create '${{ inputs.tag }}' --verify-tag --notes-from-tag --title '${{ inputs.tag }}' ${{ contains(inputs.tag, 'dev') && '--prerelease --latest=false' || '--latest=true' }}
+        cd ..
+
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ inputs.tag }}' dist/**
+        --repo '${{ github.repository }}'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale issues and prs
-        uses: actions/stale@v9.0.0
+        uses: actions/stale@v10.0.0
         with:
           repo-token: ${{ github.token }}
           days-before-stale: 90
@@ -45,7 +45,7 @@ jobs:
 
 
       - name: Needs-more-information and waiting-for-reporter stale issues policy
-        uses: actions/stale@v9.0.0
+        uses: actions/stale@v10.0.0
         with:
           repo-token: ${{ github.token }}
           only-labels: "needs-more-information,waiting-for-reporter"


### PR DESCRIPTION
Fix for this issue running publish.yml:

Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/download-artifact@v4' (SHA:d3f86a106a0bac45b974a628896c90dbdf5c8093)
Download action repository 'sigstore/gh-action-sigstore-python@v2.1.1' (SHA:61f6a500bbfdd9a2a339cf033e5421951fbc1cd2)
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
